### PR TITLE
Keep synthetic display mode OS-free

### DIFF
--- a/crates/intendant-display/src/synthetic.rs
+++ b/crates/intendant-display/src/synthetic.rs
@@ -54,6 +54,23 @@ use tokio::sync::{mpsc, Mutex};
 /// session spins up encoders only if a peer ever subscribes on demand.
 pub const KIND: &str = "synthetic";
 
+/// Controller-minted marker passed only to an `intendant-runtime` child when
+/// the fail-closed synthetic display rig is armed. The runtime is a separate
+/// process, so the process-local [`armed`] bit cannot cross that boundary.
+///
+/// This is deliberately distinct from the user-facing
+/// `INTENDANT_MOCK_DISPLAY` request. The caller validates that request against
+/// the mock provider before minting this marker; the runtime treats its
+/// presence only as a restriction (never as authority to access anything).
+pub const RUNTIME_MARKER_ENV: &str = "INTENDANT_SYNTHETIC_DISPLAY_RUNTIME";
+pub const RUNTIME_MARKER_VALUE: &str = "1";
+
+/// Whether this runtime child was constrained to the OS-free synthetic rig.
+pub fn runtime_marker_armed() -> bool {
+    std::env::var_os(RUNTIME_MARKER_ENV).as_deref()
+        == Some(std::ffi::OsStr::new(RUNTIME_MARKER_VALUE))
+}
+
 /// Synthetic source dimensions. Even on both axes (the encoder chain
 /// normalizes to even dims) and comfortably above
 /// `encode::pool::MIN_LAYER_DIM`.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -236,6 +236,24 @@ where
         .collect()
 }
 
+/// Desktop-session variables that must remain absent from commands spawned by
+/// a runtime constrained to the synthetic display rig. The controller already
+/// removes them at the runtime boundary; repeating the removal here prevents a
+/// future runtime-side environment mutation from reconnecting a descendant to
+/// the host desktop.
+const SYNTHETIC_DISPLAY_ENV_VARS: &[&str] = &[
+    "DISPLAY",
+    "WAYLAND_DISPLAY",
+    "XAUTHORITY",
+    "XDG_RUNTIME_DIR",
+    "DBUS_SESSION_BUS_ADDRESS",
+    "XDG_SESSION_TYPE",
+    "XDG_CURRENT_DESKTOP",
+    "DESKTOP_SESSION",
+    "INTENDANT_USER_DISPLAY",
+    "INTENDANT_USER_DISPLAY_GRANTED",
+];
+
 #[derive(Clone)]
 pub struct Agent {
     process_state: Arc<RwLock<HashMap<u64, ProcessInfo>>>,
@@ -243,6 +261,10 @@ pub struct Agent {
     pty_sessions: Arc<tokio::sync::Mutex<HashMap<String, PtySession>>>,
     available_displays: Vec<i32>,
     session_xauthority: Option<PathBuf>,
+    /// Restriction-only mode minted by the controller for the OS-free mock
+    /// display rig. It disables every runtime path that can discover, select,
+    /// authenticate to, or capture a native display.
+    synthetic_display_runtime: bool,
     /// See [`crate::models::AgentInput::human_response_token`].
     human_response_token: Option<String>,
     /// See [`crate::models::AgentInput::runtime_protocol_token`].
@@ -263,6 +285,7 @@ impl Agent {
             pty_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             available_displays: vec![],
             session_xauthority: None,
+            synthetic_display_runtime: false,
             human_response_token: None,
             runtime_protocol_token: None,
         })
@@ -274,9 +297,13 @@ impl Agent {
         // Resolve log directory (reuse existing session or create new)
         let log_dir = Self::resolve_log_dir()?;
 
-        // Discover X displays and merge xauth cookies
-        let available_displays = Self::discover_displays();
-        let session_xauthority = Self::setup_merged_xauthority(&available_displays, &log_dir);
+        let synthetic_display_runtime = intendant_display::synthetic::runtime_marker_armed();
+        let (available_displays, session_xauthority) = Self::initialize_display_state_with(
+            synthetic_display_runtime,
+            &log_dir,
+            Self::discover_displays,
+            Self::setup_merged_xauthority,
+        );
 
         Ok(Self {
             process_state,
@@ -284,9 +311,32 @@ impl Agent {
             pty_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             available_displays,
             session_xauthority,
+            synthetic_display_runtime,
             human_response_token: None,
             runtime_protocol_token: None,
         })
+    }
+
+    /// Resolve the native display state through injectable hooks. The
+    /// synthetic branch returns before invoking either hook: tests use
+    /// panicking hooks to prove that runtime construction cannot even consult
+    /// host-global X locks or xauth when the marker is present.
+    fn initialize_display_state_with<Discover, Xauthority>(
+        synthetic_display_runtime: bool,
+        log_dir: &Path,
+        discover: Discover,
+        xauthority: Xauthority,
+    ) -> (Vec<i32>, Option<PathBuf>)
+    where
+        Discover: FnOnce() -> Vec<i32>,
+        Xauthority: FnOnce(&[i32], &Path) -> Option<PathBuf>,
+    {
+        if synthetic_display_runtime {
+            return (Vec::new(), None);
+        }
+        let displays = discover();
+        let merged = xauthority(&displays, log_dir);
+        (displays, merged)
     }
 
     /// Adopt the batch's controller-minted askHuman answer token (see
@@ -686,20 +736,25 @@ impl Agent {
         let mut stderr_reader = stderr_file.try_clone()?;
 
         // Execute command
-        let display_id = cmd.display.unwrap_or_else(|| {
-            std::env::var("DISPLAY")
-                .ok()
-                .and_then(|d| d.trim_start_matches(':').parse().ok())
-                .unwrap_or_else(|| self.default_display())
-        });
-        // Gate user session display access
-        if display_id <= 0 && std::env::var("INTENDANT_USER_DISPLAY_GRANTED").is_err() {
-            return Err(AgentError::Process(
-                "Access to the user's session display (display :0) requires explicit grant. \
-                 Use a virtual display or request display access first."
-                    .to_string(),
-            ));
-        }
+        let display_id = if self.synthetic_display_runtime {
+            None
+        } else {
+            let display_id = cmd.display.unwrap_or_else(|| {
+                std::env::var("DISPLAY")
+                    .ok()
+                    .and_then(|d| d.trim_start_matches(':').parse().ok())
+                    .unwrap_or_else(|| self.default_display())
+            });
+            // Gate user session display access
+            if display_id <= 0 && std::env::var("INTENDANT_USER_DISPLAY_GRANTED").is_err() {
+                return Err(AgentError::Process(
+                    "Access to the user's session display (display :0) requires explicit grant. \
+                     Use a virtual display or request display access first."
+                        .to_string(),
+                ));
+            }
+            Some(display_id)
+        };
         // Platform shell: `bash -c <command>` on Unix (unchanged), `cmd.exe
         // /C <command>` on Windows where bash is not on PATH. The whole
         // command string is passed as one argument so the shell does the
@@ -709,7 +764,6 @@ impl Agent {
         let mut cmd_builder = Command::new(shell);
         cmd_builder
             .args(&shell_args)
-            .env("DISPLAY", format!(":{}", display_id))
             .env_remove("OPENAI_API_KEY")
             .env_remove("ANTHROPIC_API_KEY")
             .env_remove("GEMINI_API_KEY")
@@ -718,14 +772,24 @@ impl Agent {
             .env_remove("ANTHROPIC")
             .stdout(Stdio::from(stdout_file))
             .stderr(Stdio::from(stderr_file));
+        if let Some(display_id) = display_id {
+            cmd_builder.env("DISPLAY", format!(":{}", display_id));
+        } else {
+            for key in SYNTHETIC_DISPLAY_ENV_VARS {
+                cmd_builder.env_remove(key);
+            }
+            cmd_builder.env_remove(intendant_display::synthetic::RUNTIME_MARKER_ENV);
+        }
         // Ambient host credentials (agent sockets, cloud/forge tokens,
         // credential-store pointers) must not ride into model-driven shells
         // either; `INTENDANT_*` control vars survive.
         for name in shell_env_scrub_list(std::env::vars_os().map(|(k, _)| k)) {
             cmd_builder.env_remove(&name);
         }
-        if let Some(ref xauth) = self.session_xauthority {
-            cmd_builder.env("XAUTHORITY", xauth);
+        if !self.synthetic_display_runtime {
+            if let Some(ref xauth) = self.session_xauthority {
+                cmd_builder.env("XAUTHORITY", xauth);
+            }
         }
         let mut child = cmd_builder.spawn()?;
 
@@ -775,6 +839,13 @@ impl Agent {
     }
 
     async fn capture_screen(&self, cmd: &AgentCommand) -> Result<String, AgentError> {
+        if self.synthetic_display_runtime {
+            return Err(AgentError::Process(
+                "Legacy captureScreen is unavailable in synthetic display mode; use native \
+                 screenshot computer use."
+                    .to_string(),
+            ));
+        }
         let screenshot_path = self.log_dir.join(format!("screenshot_{}.png", cmd.nonce));
 
         // macOS: use native screencapture (no display number needed)
@@ -2050,6 +2121,83 @@ mod tests {
         let log_dir = TempDir::new().unwrap();
         let agent = Agent::new_with_paths(log_dir.path().to_path_buf()).unwrap();
         (agent, log_dir)
+    }
+
+    fn create_synthetic_test_agent() -> (Agent, TempDir) {
+        let log_dir = TempDir::new().unwrap();
+        let agent = Agent {
+            process_state: Arc::new(RwLock::new(HashMap::new())),
+            log_dir: log_dir.path().to_path_buf(),
+            pty_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            available_displays: vec![],
+            session_xauthority: None,
+            synthetic_display_runtime: true,
+            human_response_token: None,
+            runtime_protocol_token: None,
+        };
+        (agent, log_dir)
+    }
+
+    #[test]
+    fn synthetic_runtime_skips_display_discovery_and_xauthority_hooks() {
+        let log_dir = TempDir::new().unwrap();
+        let (displays, xauthority) = Agent::initialize_display_state_with(
+            true,
+            log_dir.path(),
+            || panic!("synthetic runtime consulted host-global X locks"),
+            |_, _| panic!("synthetic runtime consulted host xauthority"),
+        );
+        assert!(displays.is_empty());
+        assert!(xauthority.is_none());
+    }
+
+    #[tokio::test]
+    async fn synthetic_runtime_shell_has_no_native_display_route() {
+        let (agent, _log) = create_synthetic_test_agent();
+        #[cfg(windows)]
+        let print_environment = "set";
+        #[cfg(not(windows))]
+        let print_environment = "env";
+        let cmd = AgentCommand {
+            function: "execAsAgent".to_string(),
+            nonce: 9101,
+            command: Some(print_environment.to_string()),
+            display: Some(0),
+            ..Default::default()
+        };
+        let result = agent.exec_as_agent(&cmd).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let stdout = parsed["stdout_tail"].as_str().unwrap();
+        for key in SYNTHETIC_DISPLAY_ENV_VARS
+            .iter()
+            .copied()
+            .chain(std::iter::once(
+                intendant_display::synthetic::RUNTIME_MARKER_ENV,
+            ))
+        {
+            assert!(
+                !stdout
+                    .lines()
+                    .any(|line| line.starts_with(&format!("{key}="))),
+                "synthetic shell retained {key}: {stdout}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn synthetic_runtime_rejects_legacy_native_capture() {
+        let (agent, _log) = create_synthetic_test_agent();
+        let cmd = AgentCommand {
+            function: "captureScreen".to_string(),
+            nonce: 9102,
+            display: Some(99),
+            ..Default::default()
+        };
+        let err = agent.capture_screen(&cmd).await.unwrap_err().to_string();
+        assert!(
+            err.contains("unavailable in synthetic display mode"),
+            "{err}"
+        );
     }
 
     fn command_log_paths(log_dir: &Path, nonce: u64, stream: &str) -> Vec<PathBuf> {

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -213,12 +213,40 @@ fn apply_user_display_grant_env(cmd: &mut Command, user_display_granted: bool) {
     }
 }
 
+/// Display and desktop-session variables that a synthetic child must never
+/// inherit. The synthetic mock backend is an OS-free test seam: allowing even
+/// one of these through can reconnect a shell command to the owner's X11,
+/// Wayland, or desktop-bus session after Xvfb allocation has been skipped.
+const DISPLAY_SESSION_ENV_VARS: &[&str] = &[
+    "DISPLAY",
+    "WAYLAND_DISPLAY",
+    "XAUTHORITY",
+    "XDG_RUNTIME_DIR",
+    "DBUS_SESSION_BUS_ADDRESS",
+    "XDG_SESSION_TYPE",
+    "XDG_CURRENT_DESKTOP",
+    "DESKTOP_SESSION",
+    "INTENDANT_USER_DISPLAY",
+    USER_DISPLAY_GRANTED_ENV,
+];
+
 /// Scope one runtime child to its session-owned Xvfb. `None` preserves the
 /// ordinary inherited/user-session display selected by the existing child
-/// environment policy. A virtual child must not retain Wayland selection:
-/// otherwise GUI programs can ignore DISPLAY and connect to the owner's
-/// compositor through WAYLAND_DISPLAY/XDG_RUNTIME_DIR.
-fn apply_virtual_display_env(cmd: &mut Command, virtual_display_id: Option<u32>) {
+/// environment policy unless the fail-closed synthetic backend is armed. A
+/// virtual child must not retain Wayland selection: otherwise GUI programs
+/// can ignore DISPLAY and connect to the owner's compositor through
+/// WAYLAND_DISPLAY/XDG_RUNTIME_DIR.
+fn apply_virtual_display_env(
+    cmd: &mut Command,
+    virtual_display_id: Option<u32>,
+    synthetic_display_armed: bool,
+) {
+    if synthetic_display_armed {
+        for key in DISPLAY_SESSION_ENV_VARS {
+            cmd.env_remove(key);
+        }
+        return;
+    }
     if let Some(display_id) = virtual_display_id {
         cmd.env("DISPLAY", format!(":{display_id}"));
         #[cfg(target_os = "linux")]
@@ -881,7 +909,11 @@ async fn run_agent_inner(
     // bypass DISPLAY. `launch_display` deliberately leaves the daemon-wide
     // environment alone so concurrent sessions and browser workspaces cannot
     // inherit each other's X servers.
-    apply_virtual_display_env(&mut cmd, virtual_display_id);
+    apply_virtual_display_env(
+        &mut cmd,
+        virtual_display_id,
+        crate::display::synthetic::armed(),
+    );
 
     let mut child = cmd.spawn().map_err(|e| {
         CallerError::Agent(format!("Failed to spawn agent at {:?}: {}", agent_path, e))
@@ -1456,7 +1488,7 @@ mod tests {
         virtual_child.env("WAYLAND_DISPLAY", "wayland-0");
         virtual_child.env("XDG_RUNTIME_DIR", "/run/user/1000");
         virtual_child.env("XDG_SESSION_TYPE", "wayland");
-        apply_virtual_display_env(&mut virtual_child, Some(137));
+        apply_virtual_display_env(&mut virtual_child, Some(137), false);
         let env: std::collections::HashMap<_, _> = virtual_child.as_std().get_envs().collect();
         let display = env
             .get(std::ffi::OsStr::new("DISPLAY"))
@@ -1486,7 +1518,7 @@ mod tests {
         ordinary_child.env("WAYLAND_DISPLAY", "wayland-owner");
         ordinary_child.env("XDG_RUNTIME_DIR", "/run/user/owner");
         ordinary_child.env("XDG_SESSION_TYPE", "wayland");
-        apply_virtual_display_env(&mut ordinary_child, None);
+        apply_virtual_display_env(&mut ordinary_child, None, false);
         let ordinary_env: std::collections::HashMap<_, _> =
             ordinary_child.as_std().get_envs().collect();
         assert_eq!(
@@ -1517,6 +1549,34 @@ mod tests {
                 .and_then(std::ffi::OsStr::to_str),
             Some("wayland")
         );
+
+        let mut synthetic_child = Command::new("true");
+        for (key, value) in [
+            ("DISPLAY", ":0"),
+            ("WAYLAND_DISPLAY", "wayland-owner"),
+            ("XAUTHORITY", "/run/user/owner/xauthority"),
+            ("XDG_RUNTIME_DIR", "/run/user/owner"),
+            ("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/owner/bus"),
+            ("XDG_SESSION_TYPE", "wayland"),
+            ("XDG_CURRENT_DESKTOP", "GNOME"),
+            ("DESKTOP_SESSION", "gnome"),
+            ("INTENDANT_USER_DISPLAY", ":0"),
+            (USER_DISPLAY_GRANTED_ENV, "1"),
+        ] {
+            synthetic_child.env(key, value);
+        }
+        // Even a simultaneously supplied virtual id cannot weaken the
+        // synthetic backend's stronger OS-free boundary.
+        apply_virtual_display_env(&mut synthetic_child, Some(137), true);
+        let synthetic_env: std::collections::HashMap<_, _> =
+            synthetic_child.as_std().get_envs().collect();
+        for key in DISPLAY_SESSION_ENV_VARS {
+            assert_eq!(
+                synthetic_env.get(std::ffi::OsStr::new(key)),
+                Some(&None),
+                "synthetic child retained {key}"
+            );
+        }
     }
 
     /// A small injected cap for the drain tests — never allocate the real

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -245,8 +245,19 @@ fn apply_virtual_display_env(
         for key in DISPLAY_SESSION_ENV_VARS {
             cmd.env_remove(key);
         }
+        // The runtime is a separate process and cannot observe the caller's
+        // process-local synthetic `armed` bit. Mint a restriction-only marker
+        // so it also skips host-global X discovery and never injects DISPLAY
+        // into model-driven descendants.
+        cmd.env(
+            crate::display::synthetic::RUNTIME_MARKER_ENV,
+            crate::display::synthetic::RUNTIME_MARKER_VALUE,
+        );
         return;
     }
+    // Never honor an ambient copy: only the validated synthetic branch above
+    // may mint the marker for a runtime child.
+    cmd.env_remove(crate::display::synthetic::RUNTIME_MARKER_ENV);
     if let Some(display_id) = virtual_display_id {
         cmd.env("DISPLAY", format!(":{display_id}"));
         #[cfg(target_os = "linux")]
@@ -1577,6 +1588,35 @@ mod tests {
                 "synthetic child retained {key}"
             );
         }
+        assert_eq!(
+            synthetic_env
+                .get(std::ffi::OsStr::new(
+                    crate::display::synthetic::RUNTIME_MARKER_ENV,
+                ))
+                .and_then(|value| *value),
+            Some(std::ffi::OsStr::new(
+                crate::display::synthetic::RUNTIME_MARKER_VALUE,
+            )),
+            "synthetic child must carry the runtime fail-closed marker"
+        );
+
+        let mut ordinary_with_ambient_marker = Command::new("true");
+        ordinary_with_ambient_marker.env(
+            crate::display::synthetic::RUNTIME_MARKER_ENV,
+            crate::display::synthetic::RUNTIME_MARKER_VALUE,
+        );
+        apply_virtual_display_env(&mut ordinary_with_ambient_marker, None, false);
+        assert_eq!(
+            ordinary_with_ambient_marker
+                .as_std()
+                .get_envs()
+                .find(|(key, _)| {
+                    *key == std::ffi::OsStr::new(crate::display::synthetic::RUNTIME_MARKER_ENV)
+                })
+                .and_then(|(_, value)| value),
+            None,
+            "ordinary children must not accept an ambient synthetic marker"
+        );
     }
 
     /// A small injected cap for the drain tests — never allocate the real

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1184,6 +1184,7 @@ async fn maybe_auto_launch_xvfb(
         session_log,
         user_display_granted,
         has_cu_calls,
+        display::synthetic::armed(),
         vision::virtual_displays_supported(),
         vision::display_config_for_provider,
         |config| async move { vision::launch_display(&config).await },
@@ -1202,6 +1203,7 @@ async fn maybe_auto_launch_xvfb_with<ConfigFn, LaunchFn, LaunchFuture>(
     session_log: &SharedSessionLog,
     user_display_granted: bool,
     has_cu_calls: bool,
+    synthetic_display_armed: bool,
     virtual_displays_supported: bool,
     display_config_for_provider: ConfigFn,
     launch_display: LaunchFn,
@@ -1215,6 +1217,14 @@ where
         return Ok(());
     }
     if !facts.has_capture_screen && !facts.has_exec && !has_cu_calls {
+        return Ok(());
+    }
+    // The fail-closed mock rig's synthetic backend is explicitly OS-free.
+    // Allocating Xvfb here contradicts that contract, consumes the shared
+    // host display range, and can leave stale sockets when CI cancels a job.
+    // Native CU and capture continue through the already-armed synthetic
+    // backend; ordinary shell commands need no display at all.
+    if synthetic_display_armed {
         return Ok(());
     }
     // Xvfb is a Linux-only isolation backend. Native-display platforms keep
@@ -1656,6 +1666,7 @@ mod tests {
             &session_log,
             false,
             true,
+            false,
             true,
             |_| {
                 Some(vision::DisplayConfig {
@@ -1708,6 +1719,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             move |_| {
                 allocation_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
                 None
@@ -1748,6 +1760,7 @@ mod tests {
             &session_log,
             false,
             true,
+            false,
             true,
             |_| None,
             move |_| {
@@ -1763,6 +1776,56 @@ mod tests {
 
         let error = result.expect_err("exhausted allocation must reject native CU");
         assert!(error.contains("No unoccupied virtual display"), "{error}");
+        assert!(!launch_attempted.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(guard.is_none());
+    }
+
+    /// The mock-provider synthetic display is an OS-free test seam. Even an
+    /// exec/CU batch must not consult the allocator or launch Xvfb while it is
+    /// armed; cancelled test processes could otherwise leak host-global X11
+    /// sockets and eventually exhaust the complete virtual-display range.
+    #[tokio::test]
+    async fn synthetic_display_skips_xvfb_allocation_and_launch() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_log: SharedSessionLog = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("session")).unwrap(),
+        ));
+        let allocation_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let launch_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let allocation_attempted_in_hook = std::sync::Arc::clone(&allocation_attempted);
+        let launch_attempted_in_hook = std::sync::Arc::clone(&launch_attempted);
+        let mut guard = None;
+        let facts = BatchFacts {
+            has_exec: true,
+            ..BatchFacts::default()
+        };
+
+        let result = maybe_auto_launch_xvfb_with(
+            &facts,
+            &mut guard,
+            "mock",
+            &session_log,
+            false,
+            true,
+            true,
+            true,
+            move |_| {
+                allocation_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                None
+            },
+            move |_| {
+                launch_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                async {
+                    Err::<vision::XvfbGuard, _>(CallerError::Config(
+                        "launcher must not run".to_string(),
+                    ))
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok(()));
+        assert!(!allocation_attempted.load(std::sync::atomic::Ordering::SeqCst));
         assert!(!launch_attempted.load(std::sync::atomic::Ordering::SeqCst));
         assert!(guard.is_none());
     }

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1223,8 +1223,17 @@ where
     // Allocating Xvfb here contradicts that contract, consumes the shared
     // host display range, and can leave stale sockets when CI cancels a job.
     // Native CU and capture continue through the already-armed synthetic
-    // backend; ordinary shell commands need no display at all.
+    // backend; ordinary shell commands need no display at all. The legacy
+    // runtime captureScreen command cannot reach that backend, so reject it
+    // before the runtime can invoke an OS capture tool against inherited X11.
     if synthetic_display_armed {
+        if facts.has_capture_screen {
+            return Err(
+                "Legacy captureScreen is unavailable in synthetic display mode; the batch was \
+                 not executed and no OS display was touched. Use native screenshot computer use."
+                    .to_string(),
+            );
+        }
         return Ok(());
     }
     // Xvfb is a Linux-only isolation backend. Native-display platforms keep
@@ -1825,6 +1834,58 @@ mod tests {
         .await;
 
         assert_eq!(result, Ok(()));
+        assert!(!allocation_attempted.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!launch_attempted.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(guard.is_none());
+    }
+
+    /// Legacy captureScreen executes inside the sandbox runtime and cannot
+    /// consume SyntheticBackend frames. Reject it before allocator, launcher,
+    /// or runtime dispatch rather than letting ImageMagick touch inherited
+    /// X11. The native Screenshot CU action uses the synthetic backend.
+    #[tokio::test]
+    async fn synthetic_display_rejects_legacy_capture_without_os_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_log: SharedSessionLog = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("session")).unwrap(),
+        ));
+        let allocation_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let launch_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let allocation_attempted_in_hook = std::sync::Arc::clone(&allocation_attempted);
+        let launch_attempted_in_hook = std::sync::Arc::clone(&launch_attempted);
+        let mut guard = None;
+        let facts = BatchFacts {
+            has_capture_screen: true,
+            ..BatchFacts::default()
+        };
+
+        let result = maybe_auto_launch_xvfb_with(
+            &facts,
+            &mut guard,
+            "mock",
+            &session_log,
+            false,
+            false,
+            true,
+            true,
+            move |_| {
+                allocation_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                None
+            },
+            move |_| {
+                launch_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                async {
+                    Err::<vision::XvfbGuard, _>(CallerError::Config(
+                        "launcher must not run".to_string(),
+                    ))
+                }
+            },
+        )
+        .await;
+
+        let error = result.expect_err("legacy capture must fail before OS access");
+        assert!(error.contains("no OS display was touched"), "{error}");
+        assert!(error.contains("native screenshot"), "{error}");
         assert!(!allocation_attempted.load(std::sync::atomic::Ordering::SeqCst));
         assert!(!launch_attempted.load(std::sync::atomic::Ordering::SeqCst));
         assert!(guard.is_none());

--- a/tests/skills/peer-sessions-smoke/peer-rig.py
+++ b/tests/skills/peer-sessions-smoke/peer-rig.py
@@ -197,7 +197,17 @@ def spawn_daemon(name, home, script, cwd):
            if k not in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
                         "MODEL_NAME", "PRESENCE_PROVIDER", "PRESENCE_MODEL",
                         "CU_PROVIDER", "CU_MODEL")}
-    env.update(HOME=home, PROVIDER="mock", INTENDANT_MOCK_SCRIPT=script_path)
+    # This protocol smoke never exercises a real desktop. Arm the mock
+    # provider's fail-closed synthetic display explicitly so its shell-only
+    # exec steps cannot allocate host-global Xvfb slots (or leak them when a
+    # CI job is cancelled). Keeping the declaration in the rig also makes the
+    # OS-free contract independent of runner-service environment variables.
+    env.update(
+        HOME=home,
+        PROVIDER="mock",
+        INTENDANT_MOCK_SCRIPT=script_path,
+        INTENDANT_MOCK_DISPLAY="synthetic",
+    )
     log_path = os.path.join(home, "daemon.log")
     out = open(log_path, "w")
     # `--web 0` asks the kernel for a free port (race-free — the daemon


### PR DESCRIPTION
## Summary
- skip real Xvfb allocation whenever the fail-closed synthetic display backend is armed
- keep the existing real-display fail-closed behavior unchanged
- add a regression test proving neither the allocator nor launcher is touched

## Why
Cancelled headless E2E runs had filled the shared `:99`–`:199` range with stale X11 sockets. The suite already promises that synthetic mode touches no OS display, but shell/CU batches still attempted Xvfb allocation.

## Validation
- `cargo test -p intendant --bin intendant synthetic_display_skips_xvfb_allocation_and_launch`
- `cargo test -p intendant --bin intendant cu_only_turn_rejects_`
- `cargo clippy -p intendant --bin intendant -- -D warnings`
- `cargo test -p intendant --bins`
- `cargo test -p intendant --test e2e` (55 passed)
- `git diff --check`