### PR TITLE
Bind browser workspaces to owned virtual displays

### DIFF
--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -145,7 +145,7 @@ fn owned_xvfb_processes() -> &'static Mutex<HashMap<u32, u32>> {
 pub fn managed_virtual_display_id(display_id: u32) -> bool {
     #[cfg(target_os = "linux")]
     {
-        return (PREFERRED_DISPLAY..VIRTUAL_DISPLAY_END).contains(&display_id);
+        (PREFERRED_DISPLAY..VIRTUAL_DISPLAY_END).contains(&display_id)
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -192,10 +192,10 @@ pub fn process_owns_virtual_display(display_id: u32) -> bool {
             .lock()
             .ok()
             .and_then(|owned| owned.get(&display_id).copied());
-        return pid.is_some_and(|pid| {
+        pid.is_some_and(|pid| {
             crate::platform::process_alive(pid)
                 && xvfb_state_established(std::path::Path::new("/tmp"), display_id, pid)
-        });
+        })
     }
     #[cfg(not(target_os = "linux"))]
     {

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -434,11 +434,6 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
             ))
         }
     };
-    if !managed_virtual_display_id(display_id) {
-        return Err(CallerError::Config(format!(
-            "virtual display :{display_id} is outside Intendant's managed range"
-        )));
-    }
     let display_arg = format!(":{}", display_id);
     let screen_arg = format!("{}x{}x24", config.width, config.height);
 

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -1,10 +1,14 @@
 use intendant_core::error::CallerError;
 #[cfg(target_os = "linux")]
+use std::collections::HashMap;
+#[cfg(target_os = "linux")]
 use std::io::Read as _;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
+#[cfg(target_os = "linux")]
+use std::sync::{Mutex, OnceLock};
 use tokio::process::Child;
 
 use crate::DisplayTarget;
@@ -128,6 +132,77 @@ const PREFERRED_DISPLAY: u32 = 99;
 /// treated as user/session X servers, never as reclaimable Xvfb instances.
 #[cfg(target_os = "linux")]
 const VIRTUAL_DISPLAY_END: u32 = 200;
+
+#[cfg(target_os = "linux")]
+static OWNED_XVFB_PROCESSES: OnceLock<Mutex<HashMap<u32, u32>>> = OnceLock::new();
+
+#[cfg(target_os = "linux")]
+fn owned_xvfb_processes() -> &'static Mutex<HashMap<u32, u32>> {
+    OWNED_XVFB_PROCESSES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Whether an id belongs to Intendant's reserved virtual-display range.
+pub fn managed_virtual_display_id(display_id: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        return (PREFERRED_DISPLAY..VIRTUAL_DISPLAY_END).contains(&display_id);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = display_id;
+        false
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn register_owned_xvfb(display_id: u32, pid: u32) -> Result<(), CallerError> {
+    let mut owned = owned_xvfb_processes()
+        .lock()
+        .map_err(|_| CallerError::Config("owned Xvfb registry is unavailable".to_string()))?;
+    if let Some(existing_pid) = owned.insert(display_id, pid) {
+        if existing_pid != pid {
+            owned.insert(display_id, existing_pid);
+            return Err(CallerError::Config(format!(
+                "display :{display_id} is already owned by Xvfb process {existing_pid}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn unregister_owned_xvfb(display_id: u32, pid: u32) {
+    if let Ok(mut owned) = owned_xvfb_processes().lock() {
+        if owned.get(&display_id) == Some(&pid) {
+            owned.remove(&display_id);
+        }
+    }
+}
+
+/// Whether this process owns the live Xvfb currently serving `display_id`.
+/// A socket alone is insufficient: another service on a shared host may own
+/// it. Browser workspaces use this proof before binding a child to a display.
+pub fn process_owns_virtual_display(display_id: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        if !managed_virtual_display_id(display_id) {
+            return false;
+        }
+        let pid = owned_xvfb_processes()
+            .lock()
+            .ok()
+            .and_then(|owned| owned.get(&display_id).copied());
+        return pid.is_some_and(|pid| {
+            crate::platform::process_alive(pid)
+                && xvfb_state_established(std::path::Path::new("/tmp"), display_id, pid)
+        });
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = display_id;
+        false
+    }
+}
 
 /// Find a free X display number, preferring :99.
 ///
@@ -281,6 +356,9 @@ impl XvfbGuard {
     pub async fn shutdown(mut self) {
         #[cfg(target_os = "linux")]
         {
+            // New browser launches must stop treating this display as owned
+            // before shutdown starts, not after the child finally exits.
+            unregister_owned_xvfb(self.display_id, self.pid);
             match self.child.try_wait() {
                 Ok(Some(_)) => {
                     self.report_residual_state();
@@ -329,6 +407,8 @@ impl XvfbGuard {
 
 impl Drop for XvfbGuard {
     fn drop(&mut self) {
+        #[cfg(target_os = "linux")]
+        unregister_owned_xvfb(self.display_id, self.pid);
         // Drop cannot wait: hard-kill this guard's exact spawned child and
         // leave reaping to Tokio. Normal async teardown calls `shutdown`.
         let _ = self.child.start_kill();
@@ -354,6 +434,11 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
             ))
         }
     };
+    if !managed_virtual_display_id(display_id) {
+        return Err(CallerError::Config(format!(
+            "virtual display :{display_id} is outside Intendant's managed range"
+        )));
+    }
     let display_arg = format!(":{}", display_id);
     let screen_arg = format!("{}x{}x24", config.width, config.height);
 
@@ -405,6 +490,7 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
             "Xvfb on display {display_arg} did not establish its expected lock and socket"
         )));
     }
+    register_owned_xvfb(display_id, pid)?;
 
     Ok(XvfbGuard {
         child,
@@ -700,6 +786,30 @@ mod tests {
         assert!(virtual_display_socket_exists_in(tmp.path(), 99));
         assert!(!virtual_display_socket_exists_in(tmp.path(), 250));
         assert!(!virtual_display_socket_exists_in(tmp.path(), 150));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn managed_display_range_and_owner_registry_fail_closed() {
+        assert!(!managed_virtual_display_id(PREFERRED_DISPLAY - 1));
+        assert!(managed_virtual_display_id(PREFERRED_DISPLAY));
+        assert!(managed_virtual_display_id(VIRTUAL_DISPLAY_END - 1));
+        assert!(!managed_virtual_display_id(VIRTUAL_DISPLAY_END));
+
+        let display_id = VIRTUAL_DISPLAY_END - 1;
+        unregister_owned_xvfb(display_id, 41_001);
+        register_owned_xvfb(display_id, 41_001).unwrap();
+        assert!(register_owned_xvfb(display_id, 41_002).is_err());
+        unregister_owned_xvfb(display_id, 41_002);
+        assert_eq!(
+            owned_xvfb_processes().lock().unwrap().get(&display_id),
+            Some(&41_001)
+        );
+        unregister_owned_xvfb(display_id, 41_001);
+        assert!(!owned_xvfb_processes()
+            .lock()
+            .unwrap()
+            .contains_key(&display_id));
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -408,13 +408,17 @@ Testing into Intendant's managed cache. The wire contract already carries
 `provider` and `peer_id` fields so Playwright/Agent Browser adapters and
 federated peer-hosted browsers can slot in later. Each workspace has a lease,
 so concurrent agents must explicitly acquire it and use `force` to take over an
-active holder.
+active holder. On Linux, `display_target` can bind a local CDP workspace to a
+virtual display previously created by this same Intendant daemon (for example,
+`display_99`). Intendant rejects user-session displays, out-of-range targets,
+and X servers it does not own, and rechecks ownership immediately before
+launching the browser.
 
 | Tool                          | Description | Params |
 |-------------------------------|-------------|--------|
 | `browser_workspace_providers` | Report available workspace providers. | — |
 | `list_browser_workspaces`     | List active browser workspaces and leases. | — |
-| `create_browser_workspace`    | Launch/register a workspace. | `url?`, `label?`, `provider?`, `peer_id?`, `owner_session_id?`, `profile_dir?` |
+| `create_browser_workspace`    | Launch/register a workspace. | `url?`, `label?`, `provider?`, `peer_id?`, `owner_session_id?`, `display_target?`, `profile_dir?` |
 | `acquire_browser_workspace`   | Acquire a workspace lease. | `workspace_id`, `holder_id`, `holder_kind?`, `note?`, `force?` |
 | `release_browser_workspace`   | Release a workspace lease. | `workspace_id`, `holder_id?`, `note?` |
 | `close_browser_workspace`     | Close a workspace and terminate its local browser process when owned here. | `workspace_id`, `reason?` |

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -409,10 +409,11 @@ Testing into Intendant's managed cache. The wire contract already carries
 federated peer-hosted browsers can slot in later. Each workspace has a lease,
 so concurrent agents must explicitly acquire it and use `force` to take over an
 active holder. On Linux, `display_target` can bind a local CDP workspace to a
-virtual display previously created by this same Intendant daemon (for example,
-`display_99`). Intendant rejects user-session displays, out-of-range targets,
-and X servers it does not own, and rechecks ownership immediately before
-launching the browser.
+virtual display returned by this daemon's `create_virtual_display` tool (for
+example, `display_99`). Intendant rejects user-session, session-local,
+out-of-range, and foreign X servers. It reserves the binding before launch,
+rechecks its lifecycle before promotion, and retires the browser when that
+display is destroyed.
 
 | Tool                          | Description | Params |
 |-------------------------------|-------------|--------|

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1403,7 +1403,9 @@ browser workspaces and their leases.
 CDP workspaces prefer managed Chromium/Chrome-for-Testing executables; on macOS
 system Chrome/Chromium apps require choosing `system_cdp` or setting
 `INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER=1`. Run
-`intendant setup browsers` to install or repair the managed browser cache.
+`intendant setup browsers` to install or repair the managed browser cache. On
+Linux, callers can explicitly bind a workspace to a virtual display created by
+the same daemon; Intendant refuses user-session and foreign X servers.
 
 ### Settings
 

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -304,6 +304,52 @@ impl BrowserWorkspaceRegistry {
         Some((workspace, child))
     }
 
+    fn reconcile_display_bindings(&mut self) -> Vec<(Option<u32>, Option<Child>)> {
+        self.reconcile_display_bindings_with(crate::vision::process_owns_virtual_display)
+    }
+
+    fn reconcile_display_bindings_with(
+        &mut self,
+        display_is_live: impl Fn(u32) -> bool,
+    ) -> Vec<(Option<u32>, Option<Child>)> {
+        let stale: Vec<(String, String)> = self
+            .workspaces
+            .values()
+            .filter(|workspace| {
+                matches!(
+                    workspace.status,
+                    BrowserWorkspaceStatus::Starting | BrowserWorkspaceStatus::Ready
+                )
+            })
+            .filter_map(|workspace| {
+                let target = workspace.display_target.as_deref()?;
+                let binding = parse_browser_display_binding(target).ok()?;
+                (!display_is_live(binding.display_id))
+                    .then(|| (workspace.id.clone(), binding.canonical))
+            })
+            .collect();
+
+        stale
+            .into_iter()
+            .filter_map(|(workspace_id, display_target)| {
+                let workspace = self.workspaces.get_mut(&workspace_id)?;
+                workspace.status = BrowserWorkspaceStatus::Error;
+                workspace.lease = None;
+                workspace.message = Some(format!(
+                    "bound virtual display {display_target} is no longer live; browser stopped"
+                ));
+                workspace.updated_at = now_string();
+                workspace.debugging_port = None;
+                workspace.cdp_http_url = None;
+                workspace.cdp_ws_url = None;
+                workspace.active_target_id = None;
+                let process_id = workspace.process_id.take();
+                let child = self.children.remove(&workspace_id);
+                Some((process_id, child))
+            })
+            .collect()
+    }
+
     fn acquire(
         &mut self,
         request: AcquireBrowserWorkspaceRequest,
@@ -312,6 +358,12 @@ impl BrowserWorkspaceRegistry {
             .workspaces
             .get_mut(&request.workspace_id)
             .ok_or_else(|| BrowserWorkspaceError::NotFound(request.workspace_id.clone()))?;
+        if workspace.status != BrowserWorkspaceStatus::Ready {
+            return Err(BrowserWorkspaceError::Unsupported(format!(
+                "browser workspace '{}' is not ready (status: {:?})",
+                request.workspace_id, workspace.status
+            )));
+        }
         if let Some(lease) = workspace.lease.as_ref() {
             if lease.holder_id != request.holder_id && !request.force {
                 return Err(BrowserWorkspaceError::LeaseHeld {
@@ -670,14 +722,23 @@ pub async fn create_workspace(
 }
 
 pub async fn list_workspaces() -> Vec<BrowserWorkspace> {
-    global_registry().read().await.list()
+    let (workspaces, stale_processes) = {
+        let registry = global_registry();
+        let mut registry = registry.write().await;
+        let stale_processes = registry.reconcile_display_bindings();
+        (registry.list(), stale_processes)
+    };
+    for (process_id, child) in stale_processes {
+        terminate_workspace_process(process_id, child);
+    }
+    workspaces
 }
 
 pub async fn close_workspace(
     id: &str,
     reason: Option<String>,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
-    let (mut workspace, mut child) = global_registry()
+    let (mut workspace, child) = global_registry()
         .write()
         .await
         .remove(id)
@@ -686,7 +747,33 @@ pub async fn close_workspace(
     workspace.lease = None;
     workspace.message = reason.or_else(|| Some("closed".to_string()));
     workspace.updated_at = now_string();
-    if let Some(pid) = workspace.process_id {
+    terminate_workspace_process(workspace.process_id, child);
+    Ok(workspace)
+}
+
+pub async fn acquire_workspace(
+    request: AcquireBrowserWorkspaceRequest,
+) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
+    let (result, stale_processes) = {
+        let registry = global_registry();
+        let mut registry = registry.write().await;
+        let stale_processes = registry.reconcile_display_bindings();
+        (registry.acquire(request), stale_processes)
+    };
+    for (process_id, child) in stale_processes {
+        terminate_workspace_process(process_id, child);
+    }
+    result
+}
+
+pub async fn release_workspace(
+    request: ReleaseBrowserWorkspaceRequest,
+) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
+    global_registry().write().await.release(request)
+}
+
+fn terminate_workspace_process(process_id: Option<u32>, mut child: Option<Child>) {
+    if let Some(pid) = process_id {
         let targets = crate::platform::terminate_process_tree_now(pid);
         let still_alive: Vec<u32> = targets
             .into_iter()
@@ -702,19 +789,6 @@ pub async fn close_workspace(
     if let Some(child) = child.as_mut() {
         let _ = child.start_kill();
     }
-    Ok(workspace)
-}
-
-pub async fn acquire_workspace(
-    request: AcquireBrowserWorkspaceRequest,
-) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
-    global_registry().write().await.acquire(request)
-}
-
-pub async fn release_workspace(
-    request: ReleaseBrowserWorkspaceRequest,
-) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
-    global_registry().write().await.release(request)
 }
 
 struct CdpLaunch {
@@ -1404,6 +1478,81 @@ mod tests {
                 "unsafe display target unexpectedly accepted: {raw}"
             );
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn dead_bound_display_marks_workspace_error_and_revokes_lease() {
+        let mut registry = BrowserWorkspaceRegistry::default();
+        let mut workspace = sample_workspace("bw-dead-display");
+        workspace.display_target = Some("display_99".to_string());
+        workspace.process_id = Some(42);
+        workspace.debugging_port = Some(9222);
+        workspace.cdp_http_url = Some("http://127.0.0.1:9222".to_string());
+        workspace.cdp_ws_url = Some("ws://127.0.0.1:9222/devtools/browser/test".to_string());
+        workspace.active_target_id = Some("page-1".to_string());
+        workspace.lease = Some(BrowserWorkspaceLease {
+            holder_id: "agent-a".to_string(),
+            holder_kind: "agent".to_string(),
+            acquired_at: "2026-05-31T00:00:00.000Z".to_string(),
+            note: None,
+        });
+        registry.insert(workspace, None);
+
+        let stale = registry.reconcile_display_bindings_with(|_| false);
+
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].0, Some(42));
+        let workspace = registry.workspaces.get("bw-dead-display").unwrap();
+        assert_eq!(workspace.status, BrowserWorkspaceStatus::Error);
+        assert!(workspace.lease.is_none());
+        assert!(workspace.process_id.is_none());
+        assert!(workspace.debugging_port.is_none());
+        assert!(workspace.cdp_http_url.is_none());
+        assert!(workspace.cdp_ws_url.is_none());
+        assert!(workspace.active_target_id.is_none());
+        assert!(workspace
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("display_99 is no longer live")));
+
+        let acquire = registry.acquire(AcquireBrowserWorkspaceRequest {
+            workspace_id: "bw-dead-display".to_string(),
+            holder_id: "agent-b".to_string(),
+            holder_kind: Some("agent".to_string()),
+            note: None,
+            force: false,
+        });
+        assert!(matches!(
+            acquire,
+            Err(BrowserWorkspaceError::Unsupported(_))
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn live_bound_display_remains_ready_and_leasable() {
+        let mut registry = BrowserWorkspaceRegistry::default();
+        let mut workspace = sample_workspace("bw-live-display");
+        workspace.display_target = Some("display_99".to_string());
+        registry.insert(workspace, None);
+
+        let stale = registry.reconcile_display_bindings_with(|display_id| display_id == 99);
+
+        assert!(stale.is_empty());
+        assert_eq!(
+            registry.workspaces.get("bw-live-display").unwrap().status,
+            BrowserWorkspaceStatus::Ready
+        );
+        assert!(registry
+            .acquire(AcquireBrowserWorkspaceRequest {
+                workspace_id: "bw-live-display".to_string(),
+                holder_id: "agent-a".to_string(),
+                holder_kind: Some("agent".to_string()),
+                note: None,
+                force: false,
+            })
+            .is_ok());
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -312,17 +312,6 @@ impl BrowserWorkspaceRegistry {
         Some((workspace, child))
     }
 
-    fn mark_start_error(&mut self, id: &str, message: &str) -> Option<BrowserWorkspace> {
-        let workspace = self.workspaces.get_mut(id)?;
-        if workspace.status == BrowserWorkspaceStatus::Starting {
-            workspace.status = BrowserWorkspaceStatus::Error;
-            workspace.lease = None;
-            workspace.message = Some(message.to_string());
-            workspace.updated_at = now_string();
-        }
-        Some(workspace.clone())
-    }
-
     fn reconcile_display_bindings(&mut self) -> Vec<RetiredBrowserWorkspace> {
         self.reconcile_display_bindings_with(
             crate::virtual_display::process_owns_browser_bindable_display,
@@ -774,20 +763,14 @@ pub async fn create_workspace(
             "failed to create browser workspace profile {}: {error}",
             profile_dir.display()
         );
-        global_registry()
-            .write()
-            .await
-            .mark_start_error(&workspace.id, &message);
+        remove_failed_reservation(&workspace.id, &message, bus).await;
         return Err(BrowserWorkspaceError::Io(message));
     }
 
     let (child, cdp) = match launch_cdp_browser(&workspace, &profile_dir).await {
         Ok(launched) => launched,
         Err(error) => {
-            global_registry()
-                .write()
-                .await
-                .mark_start_error(&workspace.id, &error.to_string());
+            remove_failed_reservation(&workspace.id, &error.to_string(), bus).await;
             return Err(error);
         }
     };
@@ -853,6 +836,7 @@ pub async fn create_workspace(
         Ok(committed) => Ok(committed),
         Err(message) => {
             terminate_workspace_process(cdp.process_id, child);
+            remove_failed_reservation(&workspace.id, &message, bus).await;
             Err(BrowserWorkspaceError::Launch(message))
         }
     }
@@ -869,7 +853,11 @@ pub async fn list_workspaces(bus: &EventBus) -> Vec<BrowserWorkspace> {
     workspaces
 }
 
-pub async fn close_display_binding(display_id: u32, reason: &str) -> Vec<BrowserWorkspace> {
+pub async fn close_display_binding(
+    display_id: u32,
+    reason: &str,
+    bus: &EventBus,
+) -> Vec<BrowserWorkspace> {
     let retired = {
         let registry = global_registry();
         let mut registry = registry.write().await;
@@ -877,7 +865,14 @@ pub async fn close_display_binding(display_id: u32, reason: &str) -> Vec<Browser
         // after checking the bindable set. Removing the display here before
         // the scan therefore closes the post-scan insertion race.
         crate::virtual_display::unregister_browser_bindable_display(display_id);
-        registry.retire_workspaces_for_display(display_id, reason)
+        let retired = registry.retire_workspaces_for_display(display_id, reason);
+        // Publish each retirement before releasing the registry lock. A
+        // concurrent explicit close must therefore publish its newer Closed
+        // state after this event, never before a stale Error clone.
+        for retired in &retired {
+            publish_workspace_event(bus, "display_retired", &retired.workspace);
+        }
+        retired
     };
     retired
         .into_iter()
@@ -886,6 +881,34 @@ pub async fn close_display_binding(display_id: u32, reason: &str) -> Vec<Browser
             retired.workspace
         })
         .collect()
+}
+
+async fn remove_failed_reservation(id: &str, message: &str, bus: &EventBus) {
+    let removed = {
+        let registry = global_registry();
+        let mut registry = registry.write().await;
+        let removed = registry.remove(id);
+        if let Some((workspace, _)) = removed.as_ref() {
+            // A display teardown may already have published this reservation
+            // as Error. Serialize a terminal event with removal so the
+            // dashboard cannot retain that transient row as a ghost.
+            let mut closed = workspace.clone();
+            closed.status = BrowserWorkspaceStatus::Closed;
+            closed.lease = None;
+            closed.message = Some(message.to_string());
+            closed.updated_at = now_string();
+            bus.send(AppEvent::BrowserWorkspaceChanged {
+                kind: "closed".to_string(),
+                workspace_id: Some(closed.id.clone()),
+                message: closed.message.clone(),
+                workspace: Some(closed),
+            });
+        }
+        removed
+    };
+    if let Some((workspace, child)) = removed {
+        terminate_workspace_process(workspace.process_id, child);
+    }
 }
 
 pub async fn close_workspace(
@@ -936,14 +959,17 @@ pub async fn release_workspace(
 fn publish_reconciled_retirements(bus: &EventBus, retired: Vec<RetiredBrowserWorkspace>) {
     for retired in retired {
         terminate_workspace_process(retired.process_id, retired.child);
-        let workspace = retired.workspace;
-        bus.send(AppEvent::BrowserWorkspaceChanged {
-            kind: "display_retired".to_string(),
-            workspace_id: Some(workspace.id.clone()),
-            message: workspace.message.clone(),
-            workspace: Some(workspace),
-        });
+        publish_workspace_event(bus, "display_retired", &retired.workspace);
     }
+}
+
+fn publish_workspace_event(bus: &EventBus, kind: &str, workspace: &BrowserWorkspace) {
+    bus.send(AppEvent::BrowserWorkspaceChanged {
+        kind: kind.to_string(),
+        workspace_id: Some(workspace.id.clone()),
+        message: workspace.message.clone(),
+        workspace: Some(workspace.clone()),
+    });
 }
 
 fn terminate_workspace_process(process_id: Option<u32>, mut child: Option<Child>) {

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -1722,6 +1722,88 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn cancelled_starting_reservation_is_removed_and_closed() {
+        let id = format!("bw-cancel-test-{}", uuid::Uuid::new_v4().simple());
+        let mut workspace = sample_workspace(&id);
+        workspace.status = BrowserWorkspaceStatus::Starting;
+        global_registry().write().await.insert(workspace, None);
+
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        drop(StartingReservationGuard::new(id.clone(), bus));
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if !global_registry().read().await.workspaces.contains_key(&id) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled reservation cleanup");
+
+        match events.recv().await.expect("closed cancellation event") {
+            AppEvent::BrowserWorkspaceChanged {
+                kind,
+                workspace_id,
+                workspace: Some(workspace),
+                ..
+            } => {
+                assert_eq!(kind, "closed");
+                assert_eq!(workspace_id.as_deref(), Some(id.as_str()));
+                assert_eq!(workspace.status, BrowserWorkspaceStatus::Closed);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn acquire_publishes_serialized_lease_state() {
+        let id = format!("bw-lease-test-{}", uuid::Uuid::new_v4().simple());
+        global_registry()
+            .write()
+            .await
+            .insert(sample_workspace(&id), None);
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+
+        let acquired = acquire_workspace(
+            AcquireBrowserWorkspaceRequest {
+                workspace_id: id.clone(),
+                holder_id: "audit-agent".to_string(),
+                holder_kind: Some("agent".to_string()),
+                note: None,
+                force: false,
+            },
+            &bus,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            acquired
+                .lease
+                .as_ref()
+                .map(|lease| lease.holder_id.as_str()),
+            Some("audit-agent")
+        );
+        match events.recv().await.expect("lease event") {
+            AppEvent::BrowserWorkspaceChanged {
+                kind,
+                workspace_id,
+                workspace: Some(workspace),
+                ..
+            } => {
+                assert_eq!(kind, "lease_acquired");
+                assert_eq!(workspace_id.as_deref(), Some(id.as_str()));
+                assert_eq!(workspace, acquired);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+        global_registry().write().await.remove(&id);
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn explicit_browser_display_binding_is_strict_and_canonical() {

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -858,16 +858,14 @@ pub async fn create_workspace(
     }
 }
 
-pub async fn list_workspaces() -> Vec<BrowserWorkspace> {
+pub async fn list_workspaces(bus: &EventBus) -> Vec<BrowserWorkspace> {
     let (workspaces, retired) = {
         let registry = global_registry();
         let mut registry = registry.write().await;
         let retired = registry.reconcile_display_bindings();
         (registry.list(), retired)
     };
-    for retired in retired {
-        terminate_workspace_process(retired.process_id, retired.child);
-    }
+    publish_reconciled_retirements(bus, retired);
     workspaces
 }
 
@@ -909,6 +907,7 @@ pub async fn close_workspace(
 
 pub async fn acquire_workspace(
     request: AcquireBrowserWorkspaceRequest,
+    bus: &EventBus,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
     let (result, retired) = {
         let registry = global_registry();
@@ -916,14 +915,13 @@ pub async fn acquire_workspace(
         let retired = registry.reconcile_display_bindings();
         (registry.acquire(request), retired)
     };
-    for retired in retired {
-        terminate_workspace_process(retired.process_id, retired.child);
-    }
+    publish_reconciled_retirements(bus, retired);
     result
 }
 
 pub async fn release_workspace(
     request: ReleaseBrowserWorkspaceRequest,
+    bus: &EventBus,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
     let (result, retired) = {
         let registry = global_registry();
@@ -931,10 +929,21 @@ pub async fn release_workspace(
         let retired = registry.reconcile_display_bindings();
         (registry.release(request), retired)
     };
+    publish_reconciled_retirements(bus, retired);
+    result
+}
+
+fn publish_reconciled_retirements(bus: &EventBus, retired: Vec<RetiredBrowserWorkspace>) {
     for retired in retired {
         terminate_workspace_process(retired.process_id, retired.child);
+        let workspace = retired.workspace;
+        bus.send(AppEvent::BrowserWorkspaceChanged {
+            kind: "display_retired".to_string(),
+            workspace_id: Some(workspace.id.clone()),
+            message: workspace.message.clone(),
+            workspace: Some(workspace),
+        });
     }
-    result
 }
 
 fn terminate_workspace_process(process_id: Option<u32>, mut child: Option<Child>) {
@@ -1752,6 +1761,39 @@ mod tests {
             registry.workspaces.get("bw-survivor").unwrap().status,
             BrowserWorkspaceStatus::Ready
         );
+    }
+
+    #[test]
+    fn reconciled_display_retirement_publishes_the_error_state() {
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        let mut workspace = sample_workspace("bw-reconciled");
+        workspace.status = BrowserWorkspaceStatus::Error;
+        workspace.message = Some("bound display exited".to_string());
+
+        publish_reconciled_retirements(
+            &bus,
+            vec![RetiredBrowserWorkspace {
+                workspace: workspace.clone(),
+                process_id: None,
+                child: None,
+            }],
+        );
+
+        match events.try_recv().expect("display retirement event") {
+            AppEvent::BrowserWorkspaceChanged {
+                kind,
+                workspace_id,
+                message,
+                workspace: Some(published),
+            } => {
+                assert_eq!(kind, "display_retired");
+                assert_eq!(workspace_id.as_deref(), Some("bw-reconciled"));
+                assert_eq!(message.as_deref(), Some("bound display exited"));
+                assert_eq!(published, workspace);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -847,9 +847,10 @@ pub async fn list_workspaces(bus: &EventBus) -> Vec<BrowserWorkspace> {
         let registry = global_registry();
         let mut registry = registry.write().await;
         let retired = registry.reconcile_display_bindings();
+        publish_retirements_locked(bus, &retired);
         (registry.list(), retired)
     };
-    publish_reconciled_retirements(bus, retired);
+    terminate_retired_processes(retired);
     workspaces
 }
 
@@ -936,9 +937,10 @@ pub async fn acquire_workspace(
         let registry = global_registry();
         let mut registry = registry.write().await;
         let retired = registry.reconcile_display_bindings();
+        publish_retirements_locked(bus, &retired);
         (registry.acquire(request), retired)
     };
-    publish_reconciled_retirements(bus, retired);
+    terminate_retired_processes(retired);
     result
 }
 
@@ -950,16 +952,22 @@ pub async fn release_workspace(
         let registry = global_registry();
         let mut registry = registry.write().await;
         let retired = registry.reconcile_display_bindings();
+        publish_retirements_locked(bus, &retired);
         (registry.release(request), retired)
     };
-    publish_reconciled_retirements(bus, retired);
+    terminate_retired_processes(retired);
     result
 }
 
-fn publish_reconciled_retirements(bus: &EventBus, retired: Vec<RetiredBrowserWorkspace>) {
+fn publish_retirements_locked(bus: &EventBus, retired: &[RetiredBrowserWorkspace]) {
+    for retired in retired {
+        publish_workspace_event(bus, "display_retired", &retired.workspace);
+    }
+}
+
+fn terminate_retired_processes(retired: Vec<RetiredBrowserWorkspace>) {
     for retired in retired {
         terminate_workspace_process(retired.process_id, retired.child);
-        publish_workspace_event(bus, "display_retired", &retired.workspace);
     }
 }
 
@@ -1797,14 +1805,13 @@ mod tests {
         workspace.status = BrowserWorkspaceStatus::Error;
         workspace.message = Some("bound display exited".to_string());
 
-        publish_reconciled_retirements(
-            &bus,
-            vec![RetiredBrowserWorkspace {
-                workspace: workspace.clone(),
-                process_id: None,
-                child: None,
-            }],
-        );
+        let retired = vec![RetiredBrowserWorkspace {
+            workspace: workspace.clone(),
+            process_id: None,
+            child: None,
+        }];
+        publish_retirements_locked(&bus, &retired);
+        terminate_retired_processes(retired);
 
         match events.try_recv().expect("display retirement event") {
             AppEvent::BrowserWorkspaceChanged {

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -294,6 +294,52 @@ struct RetiredBrowserWorkspace {
     child: Option<Child>,
 }
 
+struct StartingReservationGuard {
+    workspace_id: String,
+    bus: EventBus,
+    armed: bool,
+}
+
+impl StartingReservationGuard {
+    fn new(workspace_id: String, bus: EventBus) -> Self {
+        Self {
+            workspace_id,
+            bus,
+            armed: true,
+        }
+    }
+
+    async fn cleanup(&mut self, message: &str) {
+        remove_failed_reservation(&self.workspace_id, message, &self.bus).await;
+        self.armed = false;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for StartingReservationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let workspace_id = self.workspace_id.clone();
+        let bus = self.bus.clone();
+        runtime.spawn(async move {
+            remove_failed_reservation(
+                &workspace_id,
+                "browser workspace creation was cancelled before it became ready",
+                &bus,
+            )
+            .await;
+        });
+    }
+}
+
 impl BrowserWorkspaceRegistry {
     pub fn list(&self) -> Vec<BrowserWorkspace> {
         self.workspaces.values().cloned().collect()
@@ -757,20 +803,24 @@ pub async fn create_workspace(
         }
         registry.insert(workspace.clone(), None);
     }
+    // Async cancellation can happen at every await below. The guard removes
+    // the unpublished Starting row (and any child committed just before the
+    // cancellation) so request abortion cannot leave a ghost workspace.
+    let mut reservation = StartingReservationGuard::new(workspace.id.clone(), bus.clone());
 
     if let Err(error) = std::fs::create_dir_all(&profile_dir) {
         let message = format!(
             "failed to create browser workspace profile {}: {error}",
             profile_dir.display()
         );
-        remove_failed_reservation(&workspace.id, &message, bus).await;
+        reservation.cleanup(&message).await;
         return Err(BrowserWorkspaceError::Io(message));
     }
 
     let (child, cdp) = match launch_cdp_browser(&workspace, &profile_dir).await {
         Ok(launched) => launched,
         Err(error) => {
-            remove_failed_reservation(&workspace.id, &error.to_string(), bus).await;
+            reservation.cleanup(&error.to_string()).await;
             return Err(error);
         }
     };
@@ -833,10 +883,13 @@ pub async fn create_workspace(
         }
     };
     match commit {
-        Ok(committed) => Ok(committed),
+        Ok(committed) => {
+            reservation.disarm();
+            Ok(committed)
+        }
         Err(message) => {
             terminate_workspace_process(cdp.process_id, child);
-            remove_failed_reservation(&workspace.id, &message, bus).await;
+            reservation.cleanup(&message).await;
             Err(BrowserWorkspaceError::Launch(message))
         }
     }
@@ -938,7 +991,11 @@ pub async fn acquire_workspace(
         let mut registry = registry.write().await;
         let retired = registry.reconcile_display_bindings();
         publish_retirements_locked(bus, &retired);
-        (registry.acquire(request), retired)
+        let result = registry.acquire(request);
+        if let Ok(workspace) = result.as_ref() {
+            publish_workspace_event(bus, "lease_acquired", workspace);
+        }
+        (result, retired)
     };
     terminate_retired_processes(retired);
     result
@@ -953,7 +1010,11 @@ pub async fn release_workspace(
         let mut registry = registry.write().await;
         let retired = registry.reconcile_display_bindings();
         publish_retirements_locked(bus, &retired);
-        (registry.release(request), retired)
+        let result = registry.release(request);
+        if let Ok(workspace) = result.as_ref() {
+            publish_workspace_event(bus, "lease_released", workspace);
+        }
+        (result, retired)
     };
     terminate_retired_processes(retired);
     result
@@ -1030,6 +1091,9 @@ async fn launch_cdp_browser(
     }
     let port = reserve_local_port().await?;
     let mut command = tokio::process::Command::new(&executable.path);
+    // If the async create request is cancelled while CDP readiness is being
+    // awaited, dropping its future must also terminate the spawned browser.
+    command.kill_on_drop(true);
     #[cfg(target_os = "linux")]
     if let Some(binding) = display_binding.as_ref() {
         // A bound workspace must use only its leased X11 display. Ambient

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 use tokio::process::Child;
 use tokio::sync::RwLock;
 
+use crate::event::{AppEvent, EventBus};
+
 pub type SharedBrowserWorkspaceRegistry = Arc<RwLock<BrowserWorkspaceRegistry>>;
 
 static GLOBAL_BROWSER_WORKSPACES: OnceLock<SharedBrowserWorkspaceRegistry> = OnceLock::new();
@@ -650,6 +652,7 @@ pub async fn ensure_managed_chromium(
 
 pub async fn create_workspace(
     request: CreateBrowserWorkspaceRequest,
+    bus: &EventBus,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
     let requested_provider = BrowserWorkspaceProvider::parse(request.provider.as_deref());
     let placement = match request
@@ -824,6 +827,17 @@ pub async fn create_workspace(
                     registry
                         .children
                         .insert(workspace.id.clone(), launched_child);
+                    // Publish while the registry write guard still serializes
+                    // this Ready transition with display retirement. If the
+                    // display is reaped next, its Error event must follow this
+                    // creation event; it can never be overtaken by a stale
+                    // Ready clone returned to the caller.
+                    bus.send(AppEvent::BrowserWorkspaceChanged {
+                        kind: "created".to_string(),
+                        workspace_id: Some(committed.id.clone()),
+                        workspace: Some(committed.clone()),
+                        message: None,
+                    });
                     Ok(committed)
                 } else {
                     Err("browser workspace launch child was unavailable".to_string())

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -139,6 +139,10 @@ pub struct BrowserWorkspace {
     pub preview_mode: BrowserWorkspacePreviewMode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner_session_id: Option<String>,
+    /// Canonical Intendant virtual-display target (for example,
+    /// `display_99`) when this workspace is explicitly display-bound.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_target: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -217,6 +221,10 @@ pub struct CreateBrowserWorkspaceRequest {
     pub peer_id: Option<String>,
     #[serde(default)]
     pub owner_session_id: Option<String>,
+    /// Explicit Intendant-owned virtual display (`display_99`, `:99`, or
+    /// `99`). User-session and foreign X servers are rejected.
+    #[serde(default)]
+    pub display_target: Option<String>,
     #[serde(default)]
     pub profile_dir: Option<String>,
 }
@@ -576,6 +584,19 @@ pub async fn create_workspace(
 
     let id = format!("bw-{}", uuid::Uuid::new_v4().simple());
     let created_at = now_string();
+    let display_binding = request
+        .display_target
+        .as_deref()
+        .map(parse_browser_display_binding)
+        .transpose()?;
+    if let Some(binding) = display_binding.as_ref() {
+        if !crate::vision::process_owns_virtual_display(binding.display_id) {
+            return Err(BrowserWorkspaceError::Unsupported(format!(
+                "browser workspace display {} is not a live virtual display owned by this Intendant process",
+                binding.canonical
+            )));
+        }
+    }
     let profile_dir = request
         .profile_dir
         .as_deref()
@@ -613,6 +634,7 @@ pub async fn create_workspace(
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string),
+        display_target: display_binding.map(|binding| binding.canonical),
         profile_dir: Some(profile_dir.display().to_string()),
         browser_executable: None,
         browser_executable_source: None,
@@ -711,8 +733,33 @@ async fn launch_cdp_browser(
         workspace.provider,
         BrowserWorkspaceProvider::SystemCdp
     ))?;
+    let display_binding = workspace
+        .display_target
+        .as_deref()
+        .map(parse_browser_display_binding)
+        .transpose()?;
+    if let Some(binding) = display_binding.as_ref() {
+        if !crate::vision::process_owns_virtual_display(binding.display_id) {
+            return Err(BrowserWorkspaceError::Launch(format!(
+                "browser workspace display {} stopped being owned before browser launch",
+                binding.canonical
+            )));
+        }
+    }
     let port = reserve_local_port().await?;
     let mut command = tokio::process::Command::new(&executable.path);
+    #[cfg(target_os = "linux")]
+    if let Some(binding) = display_binding.as_ref() {
+        // A bound workspace must use only its leased X11 display. Ambient
+        // Wayland/Xauthority state belongs to the daemon's login session and
+        // must not redirect or authorize this isolated browser child.
+        command
+            .env("DISPLAY", format!(":{}", binding.display_id))
+            .env("XDG_SESSION_TYPE", "x11")
+            .env_remove("WAYLAND_DISPLAY")
+            .env_remove("XAUTHORITY")
+            .arg("--ozone-platform=x11");
+    }
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -1254,6 +1301,46 @@ fn default_profile_dir(id: &str) -> PathBuf {
     base.join(id).join("profile")
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BrowserDisplayBinding {
+    canonical: String,
+    display_id: u32,
+}
+
+fn parse_browser_display_binding(
+    raw: &str,
+) -> Result<BrowserDisplayBinding, BrowserWorkspaceError> {
+    let value = raw.trim();
+    let digits = value
+        .strip_prefix("display_")
+        .or_else(|| value.strip_prefix(':'))
+        .unwrap_or(value);
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(BrowserWorkspaceError::Unsupported(format!(
+            "invalid browser workspace display target '{value}'; expected display_N, :N, or N"
+        )));
+    }
+    let display_id = digits.parse::<u32>().map_err(|_| {
+        BrowserWorkspaceError::Unsupported(format!(
+            "invalid browser workspace display target '{value}'"
+        ))
+    })?;
+    if display_id == 0 {
+        return Err(BrowserWorkspaceError::Unsupported(
+            "browser workspaces cannot bind to the user's session display".to_string(),
+        ));
+    }
+    if !crate::vision::managed_virtual_display_id(display_id) {
+        return Err(BrowserWorkspaceError::Unsupported(format!(
+            "browser workspace display :{display_id} is outside Intendant's managed virtual-display range"
+        )));
+    }
+    Ok(BrowserDisplayBinding {
+        canonical: format!("display_{display_id}"),
+        display_id,
+    })
+}
+
 fn now_string() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
@@ -1273,6 +1360,7 @@ mod tests {
             status: BrowserWorkspaceStatus::Ready,
             preview_mode: BrowserWorkspacePreviewMode::Semantic,
             owner_session_id: Some("session-1".to_string()),
+            display_target: None,
             profile_dir: None,
             browser_executable: None,
             browser_executable_source: None,
@@ -1286,6 +1374,42 @@ mod tests {
             created_at: "2026-05-31T00:00:00.000Z".to_string(),
             updated_at: "2026-05-31T00:00:00.000Z".to_string(),
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn explicit_browser_display_binding_is_strict_and_canonical() {
+        for raw in ["display_99", ":99", "99", " display_099 "] {
+            assert_eq!(
+                parse_browser_display_binding(raw).unwrap(),
+                BrowserDisplayBinding {
+                    canonical: "display_99".to_string(),
+                    display_id: 99,
+                }
+            );
+        }
+        for raw in [
+            "",
+            "user_session",
+            "display_0",
+            ":0",
+            "0",
+            "display_-1",
+            "display_98",
+            "display_200",
+            "display_99.0",
+        ] {
+            assert!(
+                parse_browser_display_binding(raw).is_err(),
+                "unsafe display target unexpectedly accepted: {raw}"
+            );
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn explicit_browser_display_binding_is_unavailable_without_managed_xvfb() {
+        assert!(parse_browser_display_binding("display_99").is_err());
     }
 
     #[test]

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -221,8 +221,8 @@ pub struct CreateBrowserWorkspaceRequest {
     pub peer_id: Option<String>,
     #[serde(default)]
     pub owner_session_id: Option<String>,
-    /// Explicit Intendant-owned virtual display (`display_99`, `:99`, or
-    /// `99`). User-session and foreign X servers are rejected.
+    /// Explicit daemon-created virtual display (`display_99`, `:99`, or
+    /// `99`). User-session, session-local, and foreign X servers are rejected.
     #[serde(default)]
     pub display_target: Option<String>,
     #[serde(default)]
@@ -310,8 +310,21 @@ impl BrowserWorkspaceRegistry {
         Some((workspace, child))
     }
 
+    fn mark_start_error(&mut self, id: &str, message: &str) -> Option<BrowserWorkspace> {
+        let workspace = self.workspaces.get_mut(id)?;
+        if workspace.status == BrowserWorkspaceStatus::Starting {
+            workspace.status = BrowserWorkspaceStatus::Error;
+            workspace.lease = None;
+            workspace.message = Some(message.to_string());
+            workspace.updated_at = now_string();
+        }
+        Some(workspace.clone())
+    }
+
     fn reconcile_display_bindings(&mut self) -> Vec<RetiredBrowserWorkspace> {
-        self.reconcile_display_bindings_with(crate::vision::process_owns_virtual_display)
+        self.reconcile_display_bindings_with(
+            crate::virtual_display::process_owns_browser_bindable_display,
+        )
     }
 
     fn reconcile_display_bindings_with(
@@ -687,25 +700,19 @@ pub async fn create_workspace(
         .map(parse_browser_display_binding)
         .transpose()?;
     if let Some(binding) = display_binding.as_ref() {
-        if !crate::vision::process_owns_virtual_display(binding.display_id) {
+        if !crate::virtual_display::process_owns_browser_bindable_display(binding.display_id) {
             return Err(BrowserWorkspaceError::Unsupported(format!(
-                "browser workspace display {} is not a live virtual display owned by this Intendant process",
+                "browser workspace display {} is not a live daemon-created virtual display",
                 binding.canonical
             )));
         }
     }
+    let bound_display_id = display_binding.as_ref().map(|binding| binding.display_id);
     let profile_dir = request
         .profile_dir
         .as_deref()
         .map(PathBuf::from)
         .unwrap_or_else(|| default_profile_dir(&id));
-    std::fs::create_dir_all(&profile_dir).map_err(|e| {
-        BrowserWorkspaceError::Io(format!(
-            "failed to create browser workspace profile {}: {e}",
-            profile_dir.display()
-        ))
-    })?;
-
     let mut workspace = BrowserWorkspace {
         label: request
             .label
@@ -747,7 +754,36 @@ pub async fn create_workspace(
         id,
     };
 
-    let (child, cdp) = launch_cdp_browser(&workspace, &profile_dir).await?;
+    // Publish the Starting reservation before filesystem work or browser
+    // launch. Display teardown can now retire this exact binding instead of
+    // racing past a workspace that exists only on this task's stack.
+    global_registry()
+        .write()
+        .await
+        .insert(workspace.clone(), None);
+
+    if let Err(error) = std::fs::create_dir_all(&profile_dir) {
+        let message = format!(
+            "failed to create browser workspace profile {}: {error}",
+            profile_dir.display()
+        );
+        global_registry()
+            .write()
+            .await
+            .mark_start_error(&workspace.id, &message);
+        return Err(BrowserWorkspaceError::Io(message));
+    }
+
+    let (child, cdp) = match launch_cdp_browser(&workspace, &profile_dir).await {
+        Ok(launched) => launched,
+        Err(error) => {
+            global_registry()
+                .write()
+                .await
+                .mark_start_error(&workspace.id, &error.to_string());
+            return Err(error);
+        }
+    };
     workspace.browser_executable = Some(cdp.executable.path.display().to_string());
     workspace.browser_executable_source = Some(cdp.executable.source);
     workspace.process_id = cdp.process_id;
@@ -759,11 +795,49 @@ pub async fn create_workspace(
     workspace.message = Some("ready".to_string());
     workspace.updated_at = now_string();
 
-    global_registry()
-        .write()
-        .await
-        .insert(workspace.clone(), Some(child));
-    Ok(workspace)
+    let mut child = Some(child);
+    let commit = {
+        let registry = global_registry();
+        let mut registry = registry.write().await;
+        let display_is_live = bound_display_id.is_none_or(|display_id| {
+            crate::virtual_display::process_owns_browser_bindable_display(display_id)
+        });
+        let current = registry.workspaces.get_mut(&workspace.id);
+        match current {
+            None => Err("browser workspace was closed during launch".to_string()),
+            Some(current) if current.status != BrowserWorkspaceStatus::Starting => Err(current
+                .message
+                .clone()
+                .unwrap_or_else(|| "browser workspace was retired during launch".to_string())),
+            Some(current) if !display_is_live => {
+                let message = "bound virtual display was retired during browser launch".to_string();
+                current.status = BrowserWorkspaceStatus::Error;
+                current.lease = None;
+                current.message = Some(message.clone());
+                current.updated_at = now_string();
+                Err(message)
+            }
+            Some(current) => {
+                if let Some(launched_child) = child.take() {
+                    *current = workspace.clone();
+                    let committed = current.clone();
+                    registry
+                        .children
+                        .insert(workspace.id.clone(), launched_child);
+                    Ok(committed)
+                } else {
+                    Err("browser workspace launch child was unavailable".to_string())
+                }
+            }
+        }
+    };
+    match commit {
+        Ok(committed) => Ok(committed),
+        Err(message) => {
+            terminate_workspace_process(cdp.process_id, child);
+            Err(BrowserWorkspaceError::Launch(message))
+        }
+    }
 }
 
 pub async fn list_workspaces() -> Vec<BrowserWorkspace> {
@@ -881,9 +955,9 @@ async fn launch_cdp_browser(
         .map(parse_browser_display_binding)
         .transpose()?;
     if let Some(binding) = display_binding.as_ref() {
-        if !crate::vision::process_owns_virtual_display(binding.display_id) {
+        if !crate::virtual_display::process_owns_browser_bindable_display(binding.display_id) {
             return Err(BrowserWorkspaceError::Launch(format!(
-                "browser workspace display {} stopped being owned before browser launch",
+                "browser workspace display {} left the daemon-created lifecycle before browser launch",
                 binding.canonical
             )));
         }
@@ -1628,6 +1702,7 @@ mod tests {
     fn display_retirement_targets_only_workspaces_bound_to_that_display() {
         let mut registry = BrowserWorkspaceRegistry::default();
         let mut retired = sample_workspace("bw-retired");
+        retired.status = BrowserWorkspaceStatus::Starting;
         retired.display_target = Some("display_99".to_string());
         retired.lease = Some(BrowserWorkspaceLease {
             holder_id: "agent-a".to_string(),

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -702,15 +702,10 @@ pub async fn create_workspace(
         .as_deref()
         .map(parse_browser_display_binding)
         .transpose()?;
-    if let Some(binding) = display_binding.as_ref() {
-        if !crate::virtual_display::process_owns_browser_bindable_display(binding.display_id) {
-            return Err(BrowserWorkspaceError::Unsupported(format!(
-                "browser workspace display {} is not a live daemon-created virtual display",
-                binding.canonical
-            )));
-        }
-    }
     let bound_display_id = display_binding.as_ref().map(|binding| binding.display_id);
+    let bound_display_target = display_binding
+        .as_ref()
+        .map(|binding| binding.canonical.clone());
     let profile_dir = request
         .profile_dir
         .as_deref()
@@ -760,10 +755,19 @@ pub async fn create_workspace(
     // Publish the Starting reservation before filesystem work or browser
     // launch. Display teardown can now retire this exact binding instead of
     // racing past a workspace that exists only on this task's stack.
-    global_registry()
-        .write()
-        .await
-        .insert(workspace.clone(), None);
+    {
+        let registry = global_registry();
+        let mut registry = registry.write().await;
+        if let Some(display_id) = bound_display_id {
+            if !crate::virtual_display::process_owns_browser_bindable_display(display_id) {
+                return Err(BrowserWorkspaceError::Unsupported(format!(
+                    "browser workspace display {} is not a live daemon-created virtual display",
+                    bound_display_target.as_deref().unwrap_or("unknown")
+                )));
+            }
+        }
+        registry.insert(workspace.clone(), None);
+    }
 
     if let Err(error) = std::fs::create_dir_all(&profile_dir) {
         let message = format!(
@@ -867,11 +871,16 @@ pub async fn list_workspaces() -> Vec<BrowserWorkspace> {
     workspaces
 }
 
-pub async fn retire_workspaces_for_display(display_id: u32, reason: &str) -> Vec<BrowserWorkspace> {
-    let retired = global_registry()
-        .write()
-        .await
-        .retire_workspaces_for_display(display_id, reason);
+pub async fn close_display_binding(display_id: u32, reason: &str) -> Vec<BrowserWorkspace> {
+    let retired = {
+        let registry = global_registry();
+        let mut registry = registry.write().await;
+        // Creation reserves its Starting row under this same registry lock
+        // after checking the bindable set. Removing the display here before
+        // the scan therefore closes the post-scan insertion race.
+        crate::virtual_display::unregister_browser_bindable_display(display_id);
+        registry.retire_workspaces_for_display(display_id, reason)
+    };
     retired
         .into_iter()
         .map(|retired| {

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -286,6 +286,12 @@ pub struct BrowserWorkspaceRegistry {
     children: HashMap<String, Child>,
 }
 
+struct RetiredBrowserWorkspace {
+    workspace: BrowserWorkspace,
+    process_id: Option<u32>,
+    child: Option<Child>,
+}
+
 impl BrowserWorkspaceRegistry {
     pub fn list(&self) -> Vec<BrowserWorkspace> {
         self.workspaces.values().cloned().collect()
@@ -304,14 +310,14 @@ impl BrowserWorkspaceRegistry {
         Some((workspace, child))
     }
 
-    fn reconcile_display_bindings(&mut self) -> Vec<(Option<u32>, Option<Child>)> {
+    fn reconcile_display_bindings(&mut self) -> Vec<RetiredBrowserWorkspace> {
         self.reconcile_display_bindings_with(crate::vision::process_owns_virtual_display)
     }
 
     fn reconcile_display_bindings_with(
         &mut self,
         display_is_live: impl Fn(u32) -> bool,
-    ) -> Vec<(Option<u32>, Option<Child>)> {
+    ) -> Vec<RetiredBrowserWorkspace> {
         let stale: Vec<(String, String)> = self
             .workspaces
             .values()
@@ -329,15 +335,50 @@ impl BrowserWorkspaceRegistry {
             })
             .collect();
 
+        self.retire_display_bindings(stale, |display_target| {
+            format!("bound virtual display {display_target} is no longer live; browser stopped")
+        })
+    }
+
+    fn retire_workspaces_for_display(
+        &mut self,
+        display_id: u32,
+        reason: &str,
+    ) -> Vec<RetiredBrowserWorkspace> {
+        let stale: Vec<(String, String)> = self
+            .workspaces
+            .values()
+            .filter(|workspace| {
+                matches!(
+                    workspace.status,
+                    BrowserWorkspaceStatus::Starting | BrowserWorkspaceStatus::Ready
+                )
+            })
+            .filter_map(|workspace| {
+                let binding =
+                    parse_browser_display_binding(workspace.display_target.as_deref()?).ok()?;
+                (binding.display_id == display_id)
+                    .then(|| (workspace.id.clone(), binding.canonical))
+            })
+            .collect();
+
+        self.retire_display_bindings(stale, |display_target| {
+            format!("bound virtual display {display_target} was retired: {reason}")
+        })
+    }
+
+    fn retire_display_bindings(
+        &mut self,
+        stale: Vec<(String, String)>,
+        message: impl Fn(&str) -> String,
+    ) -> Vec<RetiredBrowserWorkspace> {
         stale
             .into_iter()
             .filter_map(|(workspace_id, display_target)| {
                 let workspace = self.workspaces.get_mut(&workspace_id)?;
                 workspace.status = BrowserWorkspaceStatus::Error;
                 workspace.lease = None;
-                workspace.message = Some(format!(
-                    "bound virtual display {display_target} is no longer live; browser stopped"
-                ));
+                workspace.message = Some(message(&display_target));
                 workspace.updated_at = now_string();
                 workspace.debugging_port = None;
                 workspace.cdp_http_url = None;
@@ -345,7 +386,11 @@ impl BrowserWorkspaceRegistry {
                 workspace.active_target_id = None;
                 let process_id = workspace.process_id.take();
                 let child = self.children.remove(&workspace_id);
-                Some((process_id, child))
+                Some(RetiredBrowserWorkspace {
+                    workspace: workspace.clone(),
+                    process_id,
+                    child,
+                })
             })
             .collect()
     }
@@ -722,16 +767,30 @@ pub async fn create_workspace(
 }
 
 pub async fn list_workspaces() -> Vec<BrowserWorkspace> {
-    let (workspaces, stale_processes) = {
+    let (workspaces, retired) = {
         let registry = global_registry();
         let mut registry = registry.write().await;
-        let stale_processes = registry.reconcile_display_bindings();
-        (registry.list(), stale_processes)
+        let retired = registry.reconcile_display_bindings();
+        (registry.list(), retired)
     };
-    for (process_id, child) in stale_processes {
-        terminate_workspace_process(process_id, child);
+    for retired in retired {
+        terminate_workspace_process(retired.process_id, retired.child);
     }
     workspaces
+}
+
+pub async fn retire_workspaces_for_display(display_id: u32, reason: &str) -> Vec<BrowserWorkspace> {
+    let retired = global_registry()
+        .write()
+        .await
+        .retire_workspaces_for_display(display_id, reason);
+    retired
+        .into_iter()
+        .map(|retired| {
+            terminate_workspace_process(retired.process_id, retired.child);
+            retired.workspace
+        })
+        .collect()
 }
 
 pub async fn close_workspace(
@@ -754,14 +813,14 @@ pub async fn close_workspace(
 pub async fn acquire_workspace(
     request: AcquireBrowserWorkspaceRequest,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
-    let (result, stale_processes) = {
+    let (result, retired) = {
         let registry = global_registry();
         let mut registry = registry.write().await;
-        let stale_processes = registry.reconcile_display_bindings();
-        (registry.acquire(request), stale_processes)
+        let retired = registry.reconcile_display_bindings();
+        (registry.acquire(request), retired)
     };
-    for (process_id, child) in stale_processes {
-        terminate_workspace_process(process_id, child);
+    for retired in retired {
+        terminate_workspace_process(retired.process_id, retired.child);
     }
     result
 }
@@ -769,7 +828,16 @@ pub async fn acquire_workspace(
 pub async fn release_workspace(
     request: ReleaseBrowserWorkspaceRequest,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
-    global_registry().write().await.release(request)
+    let (result, retired) = {
+        let registry = global_registry();
+        let mut registry = registry.write().await;
+        let retired = registry.reconcile_display_bindings();
+        (registry.release(request), retired)
+    };
+    for retired in retired {
+        terminate_workspace_process(retired.process_id, retired.child);
+    }
+    result
 }
 
 fn terminate_workspace_process(process_id: Option<u32>, mut child: Option<Child>) {
@@ -1502,7 +1570,7 @@ mod tests {
         let stale = registry.reconcile_display_bindings_with(|_| false);
 
         assert_eq!(stale.len(), 1);
-        assert_eq!(stale[0].0, Some(42));
+        assert_eq!(stale[0].process_id, Some(42));
         let workspace = registry.workspaces.get("bw-dead-display").unwrap();
         assert_eq!(workspace.status, BrowserWorkspaceStatus::Error);
         assert!(workspace.lease.is_none());
@@ -1553,6 +1621,39 @@ mod tests {
                 force: false,
             })
             .is_ok());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn display_retirement_targets_only_workspaces_bound_to_that_display() {
+        let mut registry = BrowserWorkspaceRegistry::default();
+        let mut retired = sample_workspace("bw-retired");
+        retired.display_target = Some("display_99".to_string());
+        retired.lease = Some(BrowserWorkspaceLease {
+            holder_id: "agent-a".to_string(),
+            holder_kind: "agent".to_string(),
+            acquired_at: "2026-05-31T00:00:00.000Z".to_string(),
+            note: None,
+        });
+        let mut survivor = sample_workspace("bw-survivor");
+        survivor.display_target = Some("display_100".to_string());
+        registry.insert(retired, None);
+        registry.insert(survivor, None);
+
+        let retired = registry.retire_workspaces_for_display(99, "tile closed");
+
+        assert_eq!(retired.len(), 1);
+        assert_eq!(retired[0].workspace.id, "bw-retired");
+        assert_eq!(retired[0].workspace.status, BrowserWorkspaceStatus::Error);
+        assert!(retired[0].workspace.lease.is_none());
+        assert_eq!(
+            retired[0].workspace.message.as_deref(),
+            Some("bound virtual display display_99 was retired: tile closed")
+        );
+        assert_eq!(
+            registry.workspaces.get("bw-survivor").unwrap().status,
+            BrowserWorkspaceStatus::Ready
+        );
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/bin/caller/control_plane.rs
+++ b/src/bin/caller/control_plane.rs
@@ -857,12 +857,7 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
                 force: *force,
             };
             match crate::browser_workspace::acquire_workspace(request, &state.bus).await {
-                Ok(workspace) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
-                    kind: "lease_acquired".to_string(),
-                    workspace: Some(workspace),
-                    workspace_id: Some(workspace_id.clone()),
-                    message: None,
-                }),
+                Ok(_) => {}
                 Err(err) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
                     kind: "error".to_string(),
                     workspace: None,
@@ -882,12 +877,7 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
                 note: note.clone(),
             };
             match crate::browser_workspace::release_workspace(request, &state.bus).await {
-                Ok(workspace) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
-                    kind: "lease_released".to_string(),
-                    workspace: Some(workspace),
-                    workspace_id: Some(workspace_id.clone()),
-                    message: None,
-                }),
+                Ok(_) => {}
                 Err(err) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
                     kind: "error".to_string(),
                     workspace: None,

--- a/src/bin/caller/control_plane.rs
+++ b/src/bin/caller/control_plane.rs
@@ -803,6 +803,7 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
             provider,
             peer_id,
             owner_session_id,
+            display_target,
             profile_dir,
         } => {
             let request = crate::browser_workspace::CreateBrowserWorkspaceRequest {
@@ -811,6 +812,7 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
                 provider: provider.clone(),
                 peer_id: peer_id.clone(),
                 owner_session_id: owner_session_id.clone(),
+                display_target: display_target.clone(),
                 profile_dir: profile_dir.clone(),
             };
             match crate::browser_workspace::create_workspace(request).await {

--- a/src/bin/caller/control_plane.rs
+++ b/src/bin/caller/control_plane.rs
@@ -856,7 +856,7 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
                 note: note.clone(),
                 force: *force,
             };
-            match crate::browser_workspace::acquire_workspace(request).await {
+            match crate::browser_workspace::acquire_workspace(request, &state.bus).await {
                 Ok(workspace) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
                     kind: "lease_acquired".to_string(),
                     workspace: Some(workspace),
@@ -881,7 +881,7 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
                 holder_id: holder_id.clone(),
                 note: note.clone(),
             };
-            match crate::browser_workspace::release_workspace(request).await {
+            match crate::browser_workspace::release_workspace(request, &state.bus).await {
                 Ok(workspace) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
                     kind: "lease_released".to_string(),
                     workspace: Some(workspace),

--- a/src/bin/caller/control_plane.rs
+++ b/src/bin/caller/control_plane.rs
@@ -815,13 +815,8 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
                 display_target: display_target.clone(),
                 profile_dir: profile_dir.clone(),
             };
-            match crate::browser_workspace::create_workspace(request).await {
-                Ok(workspace) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
-                    kind: "created".to_string(),
-                    workspace: Some(workspace),
-                    workspace_id: None,
-                    message: None,
-                }),
+            match crate::browser_workspace::create_workspace(request, &state.bus).await {
+                Ok(_) => {}
                 Err(err) => state.bus.send(AppEvent::BrowserWorkspaceChanged {
                     kind: "error".to_string(),
                     workspace: None,

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -1152,6 +1152,7 @@ async fn run_browser(
                     "--provider",
                     "--peer",
                     "--session",
+                    "--display-target",
                     "--profile-dir",
                 ],
                 &[],
@@ -1165,6 +1166,7 @@ async fn run_browser(
             insert_string(&mut map, "provider", args.one("--provider"));
             insert_string(&mut map, "peer_id", args.one("--peer"));
             insert_string(&mut map, "owner_session_id", args.one("--session"));
+            insert_string(&mut map, "display_target", args.one("--display-target"));
             insert_string(&mut map, "profile_dir", args.one("--profile-dir"));
             let response = call_tool(
                 client,
@@ -6037,7 +6039,7 @@ fn help_browser() {
         "Usage:\n\
   intendant ctl browser providers\n\
   intendant ctl browser list\n\
-  intendant ctl browser create [URL] [--label TEXT] [--provider auto|cdp|system_cdp|playwright|agent_browser] [--peer PEER_ID] [--session ID] [--profile-dir PATH]\n\
+  intendant ctl browser create [URL] [--label TEXT] [--provider auto|cdp|system_cdp|playwright|agent_browser] [--peer PEER_ID] [--session ID] [--display-target display_N] [--profile-dir PATH]\n\
   intendant ctl browser acquire WORKSPACE_ID [--holder ID] [--holder-kind agent|human] [--note TEXT] [--force]\n\
   intendant ctl browser release WORKSPACE_ID [--holder ID] [--note TEXT]\n\
   intendant ctl browser close WORKSPACE_ID [--reason TEXT]\n\

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -69,8 +69,11 @@ pub(crate) async fn api_voice_session_response(
     }
 }
 
-pub(crate) async fn api_browser_workspace_snapshot_response(id: String) -> serde_json::Value {
-    let workspaces = crate::browser_workspace::list_workspaces().await;
+pub(crate) async fn api_browser_workspace_snapshot_response(
+    id: String,
+    bus: &crate::event::EventBus,
+) -> serde_json::Value {
+    let workspaces = crate::browser_workspace::list_workspaces(bus).await;
     serde_json::json!({
         "t": "response",
         "id": id,
@@ -208,7 +211,7 @@ pub(crate) async fn api_dashboard_bootstrap_response(
     }
     if !runtime.grant.is_hosted_lease() {
         if let Some(frame) = response_result(
-            api_browser_workspace_snapshot_response("bootstrap-browser".into()).await,
+            api_browser_workspace_snapshot_response("bootstrap-browser".into(), &runtime.bus).await,
         ) {
             frames.push(frame);
         }

--- a/src/bin/caller/dashboard_control/api_media.rs
+++ b/src/bin/caller/dashboard_control/api_media.rs
@@ -1347,7 +1347,11 @@ mod tests {
         assert_eq!(invalid_session["result"]["_httpStatus"], 400);
         assert_eq!(invalid_session["result"]["_httpOk"], false);
 
-        let workspace_snapshot = api_browser_workspace_snapshot_response("bw1".to_string()).await;
+        let workspace_snapshot = api_browser_workspace_snapshot_response(
+            "bw1".to_string(),
+            &crate::event::EventBus::new(),
+        )
+        .await;
         assert_eq!(workspace_snapshot["t"], "response");
         assert_eq!(workspace_snapshot["ok"], true);
         assert_eq!(

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -434,7 +434,9 @@ pub(crate) async fn control_request_frame(
         "api_displays" => api_displays_response(id, &runtime).await,
         "api_recordings" => api_recordings_response(id, &runtime).await,
         "api_session_recordings" => api_session_recordings_response(id, params.as_ref()).await,
-        "api_browser_workspace_snapshot" => api_browser_workspace_snapshot_response(id).await,
+        "api_browser_workspace_snapshot" => {
+            api_browser_workspace_snapshot_response(id, &runtime.bus).await
+        }
         "api_state_snapshot" => api_state_snapshot_response(id, &runtime).await,
         "api_display_bootstrap" => api_display_bootstrap_response(id, &runtime).await,
         "api_display_webrtc_signal" => {

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -2750,6 +2750,8 @@ pub enum ControlMsg {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         owner_session_id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        display_target: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         profile_dir: Option<String>,
     },
     CloseBrowserWorkspace {
@@ -5804,6 +5806,7 @@ mod tests {
                 provider: Some("cdp".to_string()),
                 peer_id: None,
                 owner_session_id: Some("session-1".to_string()),
+                display_target: None,
                 profile_dir: None,
             },
             ControlMsg::CloseBrowserWorkspace {

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3394,6 +3394,7 @@ pub fn spawn_user_display_listener(
                     // destroy: nothing else owns it, and leaving the Xvfb
                     // running would leak displays with no way to kill them.
                     virtual_display::reap_virtual_display(
+                        &bus,
                         &mut virtual_display_guards,
                         display_id,
                         "tile closed",
@@ -3416,6 +3417,7 @@ pub fn spawn_user_display_listener(
                         session.stop().await;
                     }
                     virtual_display::reap_virtual_display(
+                        &bus,
                         &mut virtual_display_guards,
                         display_id,
                         "capture lost",

--- a/src/bin/caller/mcp/facade.rs
+++ b/src/bin/caller/mcp/facade.rs
@@ -1944,12 +1944,15 @@ mod tests {
                 "sess-2",
                 "--peer",
                 "peer-a",
+                "--display-target",
+                "display_99",
             ]),
         )
         .unwrap();
         assert_eq!(planned.args["url"], "https://example.com");
         assert_eq!(planned.args["owner_session_id"], "sess-2");
         assert_eq!(planned.args["peer_id"], "peer-a");
+        assert_eq!(planned.args["display_target"], "display_99");
         let planned = plan_for_meta(
             "authorize",
             &argv(&[

--- a/src/bin/caller/mcp/facade/registry.rs
+++ b/src/bin/caller/mcp/facade/registry.rs
@@ -980,6 +980,12 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
             flag!("peer", "peer_id", Str, "federation peer (ctl spelling)"),
             flag!("session", "owner_session_id", Str, "owning session (ctl spelling)"),
             flag!("owner-session", "owner_session_id", Str, "owning session"),
+            flag!(
+                "display-target",
+                "display_target",
+                Str,
+                "Intendant-owned virtual display"
+            ),
             flag!("profile-dir", "profile_dir", Str, "browser profile dir"),
         ],
         help: "Create a browser workspace",

--- a/src/bin/caller/mcp/facade/registry.rs
+++ b/src/bin/caller/mcp/facade/registry.rs
@@ -984,7 +984,7 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
                 "display-target",
                 "display_target",
                 Str,
-                "Intendant-owned virtual display"
+                "daemon-created virtual display"
             ),
             flag!("profile-dir", "profile_dir", Str, "browser profile dir"),
         ],

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -813,6 +813,9 @@ pub struct CreateBrowserWorkspaceParams {
     /// Session or agent that owns this workspace.
     #[serde(default)]
     pub owner_session_id: Option<String>,
+    /// Explicit Intendant-owned virtual display (`display_99`, `:99`, or `99`). The user session and foreign X servers are rejected.
+    #[serde(default)]
+    pub display_target: Option<String>,
     /// Explicit browser profile directory. If omitted, Intendant creates one under its data dir.
     #[serde(default)]
     pub profile_dir: Option<String>,

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -813,7 +813,7 @@ pub struct CreateBrowserWorkspaceParams {
     /// Session or agent that owns this workspace.
     #[serde(default)]
     pub owner_session_id: Option<String>,
-    /// Explicit Intendant-owned virtual display (`display_99`, `:99`, or `99`). The user session and foreign X servers are rejected.
+    /// Explicit daemon-created virtual display (`display_99`, `:99`, or `99`). User-session, session-local, and foreign X servers are rejected.
     #[serde(default)]
     pub display_target: Option<String>,
     /// Explicit browser profile directory. If omitted, Intendant creates one under its data dir.

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -18,7 +18,7 @@ impl IntendantServer {
         description = "List active browser workspaces. Browser workspaces are addressable CDP/Playwright/Agent Browser surfaces with per-workspace leases."
     )]
     pub(crate) async fn list_browser_workspaces(&self) -> String {
-        let workspaces = crate::browser_workspace::list_workspaces().await;
+        let workspaces = crate::browser_workspace::list_workspaces(&self.bus).await;
         serde_json::to_string_pretty(&workspaces).unwrap_or_else(|_| "[]".to_string())
     }
 
@@ -99,7 +99,7 @@ impl IntendantServer {
             note: params.note,
             force: params.force,
         };
-        match crate::browser_workspace::acquire_workspace(request).await {
+        match crate::browser_workspace::acquire_workspace(request, &self.bus).await {
             Ok(workspace) => {
                 self.bus.send(AppEvent::BrowserWorkspaceChanged {
                     kind: "lease_acquired".to_string(),
@@ -123,7 +123,7 @@ impl IntendantServer {
             holder_id: params.holder_id,
             note: params.note,
         };
-        match crate::browser_workspace::release_workspace(request).await {
+        match crate::browser_workspace::release_workspace(request, &self.bus).await {
             Ok(workspace) => {
                 self.bus.send(AppEvent::BrowserWorkspaceChanged {
                     kind: "lease_released".to_string(),

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -23,7 +23,7 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Create a browser workspace. provider=cdp launches a managed local Chromium-family browser with an isolated profile and CDP endpoint; provider=system_cdp deliberately uses the installed system browser."
+        description = "Create a browser workspace. provider=cdp launches managed Chromium with an isolated profile and CDP endpoint. On Linux, display_target can bind it to an explicit Intendant-owned virtual display; user-session and foreign displays are rejected. provider=system_cdp deliberately uses the installed system browser."
     )]
     pub(crate) async fn create_browser_workspace(
         &self,
@@ -35,6 +35,7 @@ impl IntendantServer {
             provider: params.provider,
             peer_id: params.peer_id,
             owner_session_id: params.owner_session_id,
+            display_target: params.display_target,
             profile_dir: params.profile_dir,
         };
         match crate::browser_workspace::create_workspace(request).await {

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -38,14 +38,8 @@ impl IntendantServer {
             display_target: params.display_target,
             profile_dir: params.profile_dir,
         };
-        match crate::browser_workspace::create_workspace(request).await {
+        match crate::browser_workspace::create_workspace(request, &self.bus).await {
             Ok(workspace) => {
-                self.bus.send(AppEvent::BrowserWorkspaceChanged {
-                    kind: "created".to_string(),
-                    workspace: Some(workspace.clone()),
-                    workspace_id: Some(workspace.id.clone()),
-                    message: None,
-                });
                 serde_json::to_string_pretty(&workspace).unwrap_or_else(|_| "{}".to_string())
             }
             Err(err) => {

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -23,7 +23,7 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Create a browser workspace. provider=cdp launches managed Chromium with an isolated profile and CDP endpoint. On Linux, display_target can bind it to an explicit Intendant-owned virtual display; user-session and foreign displays are rejected. provider=system_cdp deliberately uses the installed system browser."
+        description = "Create a browser workspace. provider=cdp launches managed Chromium with an isolated profile and CDP endpoint. On Linux, display_target can bind it to an explicit daemon-created virtual display returned by create_virtual_display; user-session, session-local, and foreign displays are rejected. provider=system_cdp deliberately uses the installed system browser."
     )]
     pub(crate) async fn create_browser_workspace(
         &self,

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -101,12 +101,6 @@ impl IntendantServer {
         };
         match crate::browser_workspace::acquire_workspace(request, &self.bus).await {
             Ok(workspace) => {
-                self.bus.send(AppEvent::BrowserWorkspaceChanged {
-                    kind: "lease_acquired".to_string(),
-                    workspace_id: Some(workspace.id.clone()),
-                    workspace: Some(workspace.clone()),
-                    message: None,
-                });
                 serde_json::to_string_pretty(&workspace).unwrap_or_else(|_| "{}".to_string())
             }
             Err(err) => serde_json::json!({ "ok": false, "error": err.to_string() }).to_string(),
@@ -125,12 +119,6 @@ impl IntendantServer {
         };
         match crate::browser_workspace::release_workspace(request, &self.bus).await {
             Ok(workspace) => {
-                self.bus.send(AppEvent::BrowserWorkspaceChanged {
-                    kind: "lease_released".to_string(),
-                    workspace_id: Some(workspace.id.clone()),
-                    workspace: Some(workspace.clone()),
-                    message: None,
-                });
                 serde_json::to_string_pretty(&workspace).unwrap_or_else(|_| "{}".to_string())
             }
             Err(err) => serde_json::json!({ "ok": false, "error": err.to_string() }).to_string(),

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -25,8 +25,8 @@ use crate::frames;
 use crate::types::LogLevel;
 use crate::vision;
 use intendant_platform::DisplayTarget;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 /// Xvfb guards for dashboard-created virtual displays, keyed by display
@@ -45,6 +45,33 @@ struct VirtualDisplayOwnership {
 pub(crate) struct VirtualDisplayGuards {
     processes: HashMap<u32, vision::XvfbGuard>,
     ownership: HashMap<u32, VirtualDisplayOwnership>,
+}
+
+fn browser_bindable_displays() -> &'static Mutex<HashSet<u32>> {
+    static DISPLAYS: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
+    DISPLAYS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Whether this exact daemon-owned display participates in the correlated
+/// create/reap lifecycle that also retires browser workspaces. Generic
+/// session-local Xvfb guards are intentionally excluded.
+pub(crate) fn process_owns_browser_bindable_display(display_id: u32) -> bool {
+    browser_bindable_displays()
+        .lock()
+        .is_ok_and(|displays| displays.contains(&display_id))
+        && vision::process_owns_virtual_display(display_id)
+}
+
+fn register_browser_bindable_display(display_id: u32) {
+    if let Ok(mut displays) = browser_bindable_displays().lock() {
+        displays.insert(display_id);
+    }
+}
+
+fn unregister_browser_bindable_display(display_id: u32) {
+    if let Ok(mut displays) = browser_bindable_displays().lock() {
+        displays.remove(&display_id);
+    }
 }
 
 impl VirtualDisplayGuards {
@@ -75,6 +102,7 @@ impl VirtualDisplayGuards {
     ) {
         self.processes.insert(display_id, guard);
         self.ownership.insert(display_id, ownership);
+        register_browser_bindable_display(display_id);
     }
 
     fn remove(&mut self, display_id: &u32) -> Option<vision::XvfbGuard> {
@@ -85,6 +113,14 @@ impl VirtualDisplayGuards {
     #[cfg(test)]
     fn is_empty(&self) -> bool {
         self.processes.is_empty() && self.ownership.is_empty()
+    }
+}
+
+impl Drop for VirtualDisplayGuards {
+    fn drop(&mut self) {
+        for display_id in self.ownership.keys().copied().collect::<Vec<_>>() {
+            unregister_browser_bindable_display(display_id);
+        }
     }
 }
 
@@ -469,10 +505,15 @@ pub(crate) async fn reap_virtual_display(
                 workspace: Some(workspace),
             });
         }
+        // Keep the display browser-bindable until every dependent workspace
+        // has been atomically retired. This prevents read-time reconciliation
+        // from winning the race and suppressing the push lifecycle event.
+        unregister_browser_bindable_display(display_id);
         eprintln!("[virtual_display] destroyed :{display_id} ({context})");
         guard.shutdown().await;
         true
     } else {
+        unregister_browser_bindable_display(display_id);
         false
     }
 }

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -500,14 +500,7 @@ pub(crate) async fn reap_virtual_display(
     // while teardown removes bindability before scanning every reservation.
     // No creator can appear after the scan, and read-time reconciliation
     // cannot consume the transition before its push events are collected.
-    for workspace in crate::browser_workspace::close_display_binding(display_id, context).await {
-        bus.send(AppEvent::BrowserWorkspaceChanged {
-            kind: "display_retired".to_string(),
-            workspace_id: Some(workspace.id.clone()),
-            message: workspace.message.clone(),
-            workspace: Some(workspace),
-        });
-    }
+    crate::browser_workspace::close_display_binding(display_id, context, bus).await;
     if let Some(guard) = guard {
         eprintln!("[virtual_display] destroyed :{display_id} ({context})");
         guard.shutdown().await;

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -68,7 +68,7 @@ fn register_browser_bindable_display(display_id: u32) {
     }
 }
 
-fn unregister_browser_bindable_display(display_id: u32) {
+pub(crate) fn unregister_browser_bindable_display(display_id: u32) {
     if let Ok(mut displays) = browser_bindable_displays().lock() {
         displays.remove(&display_id);
     }
@@ -494,26 +494,25 @@ pub(crate) async fn reap_virtual_display(
     display_id: u32,
     context: &str,
 ) -> bool {
-    if let Some(guard) = guards.remove(&display_id) {
-        for workspace in
-            crate::browser_workspace::retire_workspaces_for_display(display_id, context).await
-        {
-            bus.send(AppEvent::BrowserWorkspaceChanged {
-                kind: "display_retired".to_string(),
-                workspace_id: Some(workspace.id.clone()),
-                message: workspace.message.clone(),
-                workspace: Some(workspace),
-            });
-        }
-        // Keep the display browser-bindable until every dependent workspace
-        // has been atomically retired. This prevents read-time reconciliation
-        // from winning the race and suppressing the push lifecycle event.
-        unregister_browser_bindable_display(display_id);
+    let guard = guards.remove(&display_id);
+    // The browser registry lock serializes both sides of this transition:
+    // creation checks bindability and reserves Starting under the same lock,
+    // while teardown removes bindability before scanning every reservation.
+    // No creator can appear after the scan, and read-time reconciliation
+    // cannot consume the transition before its push events are collected.
+    for workspace in crate::browser_workspace::close_display_binding(display_id, context).await {
+        bus.send(AppEvent::BrowserWorkspaceChanged {
+            kind: "display_retired".to_string(),
+            workspace_id: Some(workspace.id.clone()),
+            message: workspace.message.clone(),
+            workspace: Some(workspace),
+        });
+    }
+    if let Some(guard) = guard {
         eprintln!("[virtual_display] destroyed :{display_id} ({context})");
         guard.shutdown().await;
         true
     } else {
-        unregister_browser_bindable_display(display_id);
         false
     }
 }

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -377,7 +377,7 @@ async fn retire_virtual_display_generation(
     if let Some(session) = session_registry.write().await.remove(display_id) {
         session.stop().await;
     }
-    reap_virtual_display(guards, display_id, "capture unavailable").await;
+    reap_virtual_display(bus, guards, display_id, "capture unavailable").await;
     if let Some(request_id) = request_id {
         let _ = bus.complete_virtual_display_create(
             &request_id,
@@ -453,11 +453,22 @@ fn report_virtual_display_create_failed(
 /// Reaped on tile close (`UserDisplayRevoked`) and on capture loss (the
 /// Xvfb died, or activation never produced a session).
 pub(crate) async fn reap_virtual_display(
+    bus: &EventBus,
     guards: &mut VirtualDisplayGuards,
     display_id: u32,
     context: &str,
 ) -> bool {
     if let Some(guard) = guards.remove(&display_id) {
+        for workspace in
+            crate::browser_workspace::retire_workspaces_for_display(display_id, context).await
+        {
+            bus.send(AppEvent::BrowserWorkspaceChanged {
+                kind: "display_retired".to_string(),
+                workspace_id: Some(workspace.id.clone()),
+                message: workspace.message.clone(),
+                workspace: Some(workspace),
+            });
+        }
         eprintln!("[virtual_display] destroyed :{display_id} ({context})");
         guard.shutdown().await;
         true
@@ -776,10 +787,11 @@ mod tests {
 
     #[tokio::test]
     async fn reap_is_scoped_to_created_displays() {
+        let bus = EventBus::new();
         let mut guards = VirtualDisplayGuards::new();
         // Nothing created from the dashboard: reap must refuse — agent
         // Xvfbs and user displays are not ours to kill.
-        assert!(!reap_virtual_display(&mut guards, 99, "test").await);
+        assert!(!reap_virtual_display(&bus, &mut guards, 99, "test").await);
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -2855,7 +2855,7 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                         }
                     }
 
-                    let browser_workspaces = crate::browser_workspace::list_workspaces().await;
+                    let browser_workspaces = crate::browser_workspace::list_workspaces(&bus).await;
                     let browser_snapshot = serde_json::json!({
                         "t": "browser_workspace_snapshot",
                         "workspaces": browser_workspaces,

--- a/static/app.html
+++ b/static/app.html
@@ -39429,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '821cdd1c6b3f2d3d';
+const INTENDANT_APP_BUILD = 'ed341936f8fbb480';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -136510,10 +136510,13 @@ function handleBrowserWorkspaceMessage(d) {
     return;
   }
   if (d.event !== 'browser_workspace_changed') return;
-  if (d.workspace && d.workspace.id) {
-    browserWorkspaces.set(String(d.workspace.id), d.workspace);
-  } else if (d.workspace_id && d.kind === 'closed') {
+  // Closed is a tombstone even when older/newer senders include the final
+  // workspace snapshot. Prioritizing the payload retained a hidden Closed
+  // row forever and let failed Starting reservations accumulate client-side.
+  if (d.workspace_id && d.kind === 'closed') {
     browserWorkspaces.delete(String(d.workspace_id));
+  } else if (d.workspace && d.workspace.id) {
+    browserWorkspaces.set(String(d.workspace.id), d.workspace);
   }
   const status = document.getElementById('browser-workspace-status');
   if (status && d.kind === 'error') {
@@ -138600,7 +138603,6 @@ function renderAggregateStatTiles(el, cards) {
     el.appendChild(card);
   }
 }
-
 /* ── static/app/57a-sessions-list.js ── */
 // ── Sessions list rendering: windowed, signature-guarded, node-stable ──
 // The corpus (_cachedSessions) can be thousands of rows; the DOM holds only

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -186,10 +186,13 @@ function handleBrowserWorkspaceMessage(d) {
     return;
   }
   if (d.event !== 'browser_workspace_changed') return;
-  if (d.workspace && d.workspace.id) {
-    browserWorkspaces.set(String(d.workspace.id), d.workspace);
-  } else if (d.workspace_id && d.kind === 'closed') {
+  // Closed is a tombstone even when older/newer senders include the final
+  // workspace snapshot. Prioritizing the payload retained a hidden Closed
+  // row forever and let failed Starting reservations accumulate client-side.
+  if (d.workspace_id && d.kind === 'closed') {
     browserWorkspaces.delete(String(d.workspace_id));
+  } else if (d.workspace && d.workspace.id) {
+    browserWorkspaces.set(String(d.workspace.id), d.workspace);
   }
   const status = document.getElementById('browser-workspace-status');
   if (status && d.kind === 'error') {
@@ -2276,4 +2279,3 @@ function renderAggregateStatTiles(el, cards) {
     el.appendChild(card);
   }
 }
-


### PR DESCRIPTION
## Summary

Allow a local CDP browser workspace to target an explicit virtual display owned by the same Intendant process. The launch rechecks ownership immediately before spawning Chromium and refuses user-session, out-of-range, or foreign displays.

This also carries the canonical `display_target` through MCP, CLI, events, and workspace state so callers can verify browser/display correlation.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p intendant-platform vision`
- `cargo test -p intendant --bin intendant browser_workspace`
- `git diff --check origin/main...HEAD`