### PR TITLE
Authenticate daemon-owned Xvfb workspaces

### DIFF
--- a/crates/intendant-display/src/capture/x11_damage.rs
+++ b/crates/intendant-display/src/capture/x11_damage.rs
@@ -64,8 +64,16 @@ impl X11DamageBackend {
     /// unavailable on the X server — caller should fall back to a
     /// [`super::damage::NullDamageBackend`] in that case.
     pub fn new(display_str: &str) -> Result<Self, DamageError> {
-        let (conn, screen_num) =
-            x11rb::connect(Some(display_str)).map_err(|e| DamageError::Connect(e.to_string()))?;
+        let connection = crate::x11_input::X11Connection::unauthenticated(display_str);
+        Self::with_connection(&connection)
+    }
+
+    /// Set up XDamage over the exact connection identity used by the capture
+    /// backend, including its private per-display authorization when present.
+    pub fn with_connection(
+        connection: &crate::x11_input::X11Connection,
+    ) -> Result<Self, DamageError> {
+        let (conn, screen_num) = connection.connect().map_err(DamageError::Connect)?;
 
         // Verify both required extensions are present BEFORE making any
         // protocol-specific calls. This is the explicit-degradation

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1337,16 +1337,24 @@ pub trait DisplayBackend: Send + Sync + 'static {
     /// Human-readable backend name (e.g. "wayland", "x11").
     fn kind(&self) -> &'static str;
 
-    /// The X11 display string this backend actually captures (e.g.
-    /// `":99"`), for consumers that must open their own connection to
-    /// the same server — the XDamage tile-damage backend in particular.
-    /// `None` for non-X11 backends; the damage layer then falls back to
-    /// the process `DISPLAY`. Without this hint a session created via
-    /// `X11Backend::with_display` while `DISPLAY` points elsewhere would
-    /// attach XDamage to the wrong X server.
-    fn x11_display_hint(&self) -> Option<String> {
+    /// The exact X11 connection this backend captures, for consumers that
+    /// must open an independent authenticated connection to the same server
+    /// (the XDamage tile-damage backend in particular). `None` for non-X11
+    /// backends; the damage layer then falls back to the process `DISPLAY`.
+    fn x11_damage_hint(&self) -> Option<X11DamageHint> {
         None
     }
+}
+
+/// In-process X11 damage-tracker connection material. This deliberately has
+/// no serialization or debug representation: private-display authorization
+/// must not enter logs, events, or portable receipts.
+#[derive(Clone)]
+pub struct X11DamageHint {
+    #[cfg(target_os = "linux")]
+    display: String,
+    #[cfg(target_os = "linux")]
+    connection: x11_input::X11Connection,
 }
 
 // ---------------------------------------------------------------------------
@@ -1884,22 +1892,28 @@ fn make_damage_backend(
     width: u32,
     height: u32,
     backend_kind: &'static str,
-    x11_display_hint: Option<&str>,
+    x11_damage_hint: Option<&X11DamageHint>,
 ) -> Box<dyn capture::damage::DamageBackend> {
     #[cfg(not(target_os = "linux"))]
-    let _ = (backend_kind, x11_display_hint);
+    let _ = (backend_kind, x11_damage_hint);
 
     #[cfg(target_os = "linux")]
     {
         if should_try_xdamage_for_tile_stream(backend_kind) {
-            // The capturing backend's own display string wins: a session
-            // on `:99` must not damage-track whatever the process-wide
-            // DISPLAY happens to name.
-            let display = x11_display_hint
-                .map(str::to_string)
-                .or_else(|| std::env::var("DISPLAY").ok())
-                .unwrap_or_else(|| ":0".to_string());
-            match capture::x11_damage::X11DamageBackend::new(&display) {
+            // The capturing backend's exact authenticated connection wins: a
+            // private session on :99 must neither attach to process DISPLAY
+            // nor rely on ambient Xauthority discovery.
+            let fallback_display = std::env::var("DISPLAY").unwrap_or_else(|_| ":0".to_string());
+            let display = x11_damage_hint
+                .map(|hint| hint.display.as_str())
+                .unwrap_or(fallback_display.as_str());
+            let result = match x11_damage_hint {
+                Some(hint) => {
+                    capture::x11_damage::X11DamageBackend::with_connection(&hint.connection)
+                }
+                None => capture::x11_damage::X11DamageBackend::new(display),
+            };
+            match result {
                 Ok(backend) => {
                     eprintln!("[display/tile] XDamage backend enabled on DISPLAY={display}");
                     return Box::new(backend);
@@ -3643,7 +3657,7 @@ impl DisplaySession {
         let session_epoch = self.session_epoch;
         let (initial_w, initial_h) = self.backend.resolution();
         let backend_kind = self.backend.kind();
-        let x11_display_hint = self.backend.x11_display_hint();
+        let x11_damage_hint = self.backend.x11_damage_hint();
         // Tile-standby plumbing (per-peer RTP standby under tile mode):
         // the bridge owns every standby transition, mirrors the mode
         // into `tile_video_active` for the Subscribe handler, kicks the
@@ -3660,12 +3674,8 @@ impl DisplaySession {
         let pool_feed_kf_tx = self.pool_feed_keyframe_tx.lock().await.clone();
 
         let task = tokio::spawn(async move {
-            let mut damage = make_damage_backend(
-                initial_w,
-                initial_h,
-                backend_kind,
-                x11_display_hint.as_deref(),
-            );
+            let mut damage =
+                make_damage_backend(initial_w, initial_h, backend_kind, x11_damage_hint.as_ref());
             // `Option` so the tracker can round-trip through the
             // spawn_blocking diff below (moved in, moved back out).
             let mut frame_diff: Option<capture::frame_diff::FrameDiffDamageTracker> = Some(

--- a/crates/intendant-display/src/tile_socket.rs
+++ b/crates/intendant-display/src/tile_socket.rs
@@ -81,12 +81,12 @@ impl DisplaySession {
         let session_epoch = self.session_epoch;
         let display_id = self.display_id;
         let backend_kind = self.backend.kind();
-        let display_hint = self.backend.x11_display_hint();
+        let damage_hint = self.backend.x11_damage_hint();
         let (initial_w, initial_h) = self.backend.resolution();
 
         let task = tokio::spawn(async move {
             let mut damage =
-                make_damage_backend(initial_w, initial_h, backend_kind, display_hint.as_deref());
+                make_damage_backend(initial_w, initial_h, backend_kind, damage_hint.as_ref());
             let mut frame_diff: Option<capture::frame_diff::FrameDiffDamageTracker> = Some(
                 capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX),
             );

--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -1,4 +1,4 @@
-//! X11 display backend using XShm for frame capture and xdotool for input
+//! X11 display backend using XShm for frame capture and XTest for input
 //! injection.
 //!
 //! The XShm capture loop runs on a dedicated `std::thread` (the X11 connection
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use x11rb::connection::Connection;
 
+use crate::x11_input::X11Connection;
+
 /// Active capture state: holds the thread handle for cleanup.
 struct CaptureState {
     thread: std::thread::JoinHandle<()>,
@@ -25,15 +27,15 @@ struct CaptureState {
 
 /// X11 screen capture and input injection backend.
 ///
-/// Uses `x11rb` with the XShm extension for fast full-screen capture and
-/// shells out to `xdotool` for keyboard/mouse/scroll input injection (same
-/// approach as the existing `computer_use.rs` X11 backend).
+/// Uses `x11rb` with the XShm extension for fast full-screen capture and a
+/// shared authenticated XTest connection for keyboard/mouse/scroll input.
 pub struct X11Backend {
     capture: Mutex<Option<CaptureState>>,
     width: Arc<AtomicU32>,
     height: Arc<AtomicU32>,
     shutdown: Arc<AtomicBool>,
     display: String,
+    connection: X11Connection,
     /// Demand probe slot shared with the capture thread. X11 capture is
     /// a full-screen copy at configured fps whether or not anything
     /// consumes it (~249 MB/s at 1080p30), so this polling backend is
@@ -51,9 +53,11 @@ impl X11Backend {
     /// setup -- the capture thread creates its own connection.
     pub fn new() -> Result<Self, CallerError> {
         let display_str = std::env::var("DISPLAY").unwrap_or_else(|_| ":0".to_string());
+        let connection = X11Connection::unauthenticated(&display_str);
 
         // Probe the display to get resolution.
-        let (conn, screen_num) = x11rb::connect(Some(&display_str))
+        let (conn, screen_num) = connection
+            .connect()
             .map_err(|e| CallerError::Display(format!("X11 connect: {e}")))?;
 
         let setup = conn.setup();
@@ -68,6 +72,7 @@ impl X11Backend {
             height: Arc::new(AtomicU32::new(height)),
             shutdown: Arc::new(AtomicBool::new(false)),
             display: display_str,
+            connection,
             demand: Arc::new(DemandProbeSlot::new()),
         })
     }
@@ -76,7 +81,25 @@ impl X11Backend {
     /// Virtual display sessions use this to connect to their own Xvfb server
     /// regardless of where the process-wide `DISPLAY` points.
     pub fn with_display(display_str: &str) -> Result<Self, CallerError> {
-        let (conn, screen_num) = x11rb::connect(Some(display_str))
+        Self::with_connection(X11Connection::unauthenticated(display_str))
+    }
+
+    /// Create a backend for a private local X11 display using the exact
+    /// authorization bytes owned by its controller.
+    pub fn with_display_authorization(
+        display_str: &str,
+        protocol: &[u8],
+        cookie: &[u8],
+    ) -> Result<Self, CallerError> {
+        let connection = X11Connection::authenticated(display_str, protocol, cookie)
+            .map_err(CallerError::Display)?;
+        Self::with_connection(connection)
+    }
+
+    fn with_connection(connection: X11Connection) -> Result<Self, CallerError> {
+        let display_str = connection.display().to_string();
+        let (conn, screen_num) = connection
+            .connect()
             .map_err(|e| CallerError::Display(format!("X11 connect to {display_str}: {e}")))?;
 
         let setup = conn.setup();
@@ -89,9 +112,20 @@ impl X11Backend {
             width: Arc::new(AtomicU32::new(width)),
             height: Arc::new(AtomicU32::new(height)),
             shutdown: Arc::new(AtomicBool::new(false)),
-            display: display_str.to_string(),
+            display: display_str,
+            connection,
             demand: Arc::new(DemandProbeSlot::new()),
         })
+    }
+}
+
+impl Drop for X11Backend {
+    fn drop(&mut self) {
+        // Private displays use a fresh cookie for every lifecycle. Evict its
+        // input connection so dead credentials cannot accumulate across the
+        // thousands of short-lived evidence captures this backend serves.
+        // The connection's event thread exits when the owned Xvfb closes.
+        crate::x11_input::forget_authenticated(&self.connection);
     }
 }
 
@@ -238,7 +272,7 @@ impl DisplayBackend for X11Backend {
 
         let (tx, rx) = mpsc::channel::<Frame>(4);
         let shutdown_flag = Arc::clone(&self.shutdown);
-        let display_str = self.display.clone();
+        let connection = self.connection.clone();
         let width = self.width.load(Ordering::SeqCst);
         let height = self.height.load(Ordering::SeqCst);
         let shared_w = Arc::clone(&self.width);
@@ -247,7 +281,7 @@ impl DisplayBackend for X11Backend {
 
         let thread = std::thread::spawn(move || {
             run_x11_capture(
-                display_str,
+                connection,
                 tx,
                 shutdown_flag,
                 fps,
@@ -296,39 +330,39 @@ impl DisplayBackend for X11Backend {
     async fn inject_input(&self, event: InputEvent) -> Result<(), CallerError> {
         let width = self.width.load(Ordering::SeqCst) as f64;
         let height = self.height.load(Ordering::SeqCst) as f64;
-        let display = &self.display;
+        let connection = &self.connection;
 
         // In-process XTest injection over the shared per-display connection
         // (crate::x11_input) — no xdotool fork per browser input event.
         match event {
             InputEvent::KeyDown { ref code, .. } => {
-                crate::x11_input::key_sequence(display, vec![(code.clone(), true)])
+                crate::x11_input::key_sequence_on(connection, vec![(code.clone(), true)])
                     .await
                     .map_err(CallerError::Display)?;
             }
             InputEvent::KeyUp { ref code, .. } => {
-                crate::x11_input::key_sequence(display, vec![(code.clone(), false)])
+                crate::x11_input::key_sequence_on(connection, vec![(code.clone(), false)])
                     .await
                     .map_err(CallerError::Display)?;
             }
             InputEvent::MouseMove { x, y, .. } => {
                 let px = (x * width) as i32;
                 let py = (y * height) as i32;
-                crate::x11_input::move_mouse(display, px, py)
+                crate::x11_input::move_mouse_on(connection, px, py)
                     .await
                     .map_err(CallerError::Display)?;
             }
             InputEvent::MouseDown { x, y, b } => {
                 let px = (x * width) as i32;
                 let py = (y * height) as i32;
-                crate::x11_input::mouse_down(display, px, py, x11_button_from_browser(b))
+                crate::x11_input::mouse_down_on(connection, px, py, x11_button_from_browser(b))
                     .await
                     .map_err(CallerError::Display)?;
             }
             InputEvent::MouseUp { x, y, b } => {
                 let px = (x * width) as i32;
                 let py = (y * height) as i32;
-                crate::x11_input::mouse_up(display, px, py, x11_button_from_browser(b))
+                crate::x11_input::mouse_up_on(connection, px, py, x11_button_from_browser(b))
                     .await
                     .map_err(CallerError::Display)?;
             }
@@ -339,7 +373,7 @@ impl DisplayBackend for X11Backend {
                 if dy.abs() > f64::EPSILON {
                     let steps = dy.abs().round().max(1.0) as u32;
                     let button = if dy < 0.0 { 4 } else { 5 };
-                    crate::x11_input::scroll(display, px, py, button, steps)
+                    crate::x11_input::scroll_on(connection, px, py, button, steps)
                         .await
                         .map_err(CallerError::Display)?;
                 }
@@ -347,13 +381,32 @@ impl DisplayBackend for X11Backend {
                 if dx.abs() > f64::EPSILON {
                     let steps = dx.abs().round().max(1.0) as u32;
                     let button = if dx < 0.0 { 6 } else { 7 };
-                    crate::x11_input::scroll(display, px, py, button, steps)
+                    crate::x11_input::scroll_on(connection, px, py, button, steps)
                         .await
                         .map_err(CallerError::Display)?;
                 }
             }
         }
         Ok(())
+    }
+
+    async fn inject_text(&self, text: &str) -> Result<(), CallerError> {
+        crate::x11_input::type_text_on(&self.connection, text)
+            .await
+            .map_err(CallerError::Display)
+    }
+
+    async fn paste_text(&self, text: &str) -> Result<super::PasteOutcome, CallerError> {
+        crate::x11_input::paste_on(&self.connection, text)
+            .await
+            .map_err(CallerError::Display)?;
+        Ok(super::PasteOutcome {
+            clipboard_note: Some(
+                "clipboard: previous content not restored (X11 selections are pull-based); \
+                 the pasted text remains the CLIPBOARD selection"
+                    .to_string(),
+            ),
+        })
     }
 
     fn set_capture_demand_probe(&self, probe: pacing::CaptureDemandProbe) {
@@ -397,7 +450,7 @@ fn x11_button_from_browser(b: u8) -> u8 {
 /// and loops at the target framerate sending frames via `try_send()`.
 #[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 fn run_x11_capture(
-    display_str: String,
+    connection: X11Connection,
     tx: mpsc::Sender<Frame>,
     shutdown: Arc<AtomicBool>,
     fps: u32,
@@ -413,7 +466,7 @@ fn run_x11_capture(
     let frame_interval =
         std::time::Duration::from_millis(if fps > 0 { 1000 / fps as u64 } else { 33 });
 
-    let (conn, screen_num) = match x11rb::connect(Some(&display_str)) {
+    let (conn, screen_num) = match connection.connect() {
         Ok(c) => c,
         Err(e) => {
             eprintln!("[display/x11] X11 connect failed: {e}");

--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -424,8 +424,11 @@ impl DisplayBackend for X11Backend {
         "x11"
     }
 
-    fn x11_display_hint(&self) -> Option<String> {
-        Some(self.display.clone())
+    fn x11_damage_hint(&self) -> Option<super::X11DamageHint> {
+        Some(super::X11DamageHint {
+            display: self.display.clone(),
+            connection: self.connection.clone(),
+        })
     }
 }
 

--- a/crates/intendant-display/src/x11_input.rs
+++ b/crates/intendant-display/src/x11_input.rs
@@ -18,6 +18,7 @@
 //! functions wrap the work in `spawn_blocking`.
 
 use std::collections::HashMap;
+use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -25,7 +26,7 @@ use x11rb::connection::Connection;
 use x11rb::protocol::xproto::{self, ConnectionExt as _};
 use x11rb::protocol::xtest::ConnectionExt as _;
 use x11rb::protocol::Event;
-use x11rb::rust_connection::RustConnection;
+use x11rb::rust_connection::{DefaultStream, RustConnection};
 use x11rb::wrapper::ConnectionExt as _;
 
 use crate::keymap::{char_to_x11_keysym, dom_code_to_x11_keycode};
@@ -42,6 +43,82 @@ const DRAG_STEPS: i32 = 5;
 const PASTE_TRANSFER_WINDOW: Duration = Duration::from_millis(500);
 /// Refuse pastes larger than this rather than implementing INCR transfers.
 const PASTE_MAX_BYTES: usize = 1 << 20;
+const X11_AUTH_PROTOCOL: &[u8] = b"MIT-MAGIC-COOKIE-1";
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct X11Authorization {
+    protocol: Vec<u8>,
+    cookie: Vec<u8>,
+}
+
+/// Exact connection identity for one X11 server. Authenticated connections
+/// always use the display's local Unix socket; an auth cookie can therefore
+/// never authorize a caller-selected TCP endpoint.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct X11Connection {
+    display: String,
+    authorization: Option<X11Authorization>,
+}
+
+impl X11Connection {
+    #[must_use]
+    pub fn unauthenticated(display: impl Into<String>) -> Self {
+        Self {
+            display: display.into(),
+            authorization: None,
+        }
+    }
+
+    pub fn authenticated(
+        display: impl Into<String>,
+        protocol: &[u8],
+        cookie: &[u8],
+    ) -> Result<Self, String> {
+        let display = display.into();
+        parse_local_display_id(&display)?;
+        if protocol != X11_AUTH_PROTOCOL {
+            return Err("unsupported X11 authorization protocol".to_string());
+        }
+        if cookie.len() != 16 {
+            return Err("MIT-MAGIC-COOKIE-1 data must contain exactly 16 bytes".to_string());
+        }
+        Ok(Self {
+            display,
+            authorization: Some(X11Authorization {
+                protocol: protocol.to_vec(),
+                cookie: cookie.to_vec(),
+            }),
+        })
+    }
+
+    #[must_use]
+    pub fn display(&self) -> &str {
+        &self.display
+    }
+
+    #[must_use]
+    pub(crate) fn is_authenticated(&self) -> bool {
+        self.authorization.is_some()
+    }
+
+    pub(crate) fn connect(&self) -> Result<(RustConnection, usize), String> {
+        connect_protocol(self)
+    }
+}
+
+fn parse_local_display_id(display: &str) -> Result<u32, String> {
+    let digits = display
+        .strip_prefix(':')
+        .ok_or_else(|| format!("authenticated X11 display must be local: {display}"))?;
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(format!(
+            "authenticated X11 display must have the exact :N form: {display}"
+        ));
+    }
+    digits
+        .parse::<u32>()
+        .map_err(|_| format!("authenticated X11 display is out of range: {display}"))
+}
 
 // ── Connection cache ─────────────────────────────────────────────────────────
 
@@ -110,39 +187,45 @@ impl From<x11rb::errors::ReplyOrIdError> for OpError {
     }
 }
 
-fn cache() -> &'static Mutex<HashMap<String, Arc<DisplayConn>>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, Arc<DisplayConn>>>> = OnceLock::new();
+fn cache() -> &'static Mutex<HashMap<X11Connection, Arc<DisplayConn>>> {
+    static CACHE: OnceLock<Mutex<HashMap<X11Connection, Arc<DisplayConn>>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn invalidate(display: &str) {
-    cache().lock().unwrap().remove(display);
+fn invalidate(connection: &X11Connection) {
+    cache().lock().unwrap().remove(connection);
 }
 
-fn connect_cached(display: &str) -> Result<Arc<DisplayConn>, String> {
-    if let Some(dc) = cache().lock().unwrap().get(display) {
+pub(crate) fn forget_authenticated(connection: &X11Connection) {
+    if connection.is_authenticated() {
+        invalidate(connection);
+    }
+}
+
+fn connect_cached(connection: &X11Connection) -> Result<Arc<DisplayConn>, String> {
+    if let Some(dc) = cache().lock().unwrap().get(connection) {
         return Ok(dc.clone());
     }
-    let dc = Arc::new(connect(display)?);
+    let dc = Arc::new(connect(connection)?);
     // Dedicated event thread per connection: the single consumer of the X
     // event queue. It answers clipboard SelectionRequests (paste serving) and
     // exits when the connection dies. x11rb routes replies to their waiting
     // requesters independently of this queue, so blocking here is safe.
     let event_dc = dc.clone();
     std::thread::Builder::new()
-        .name(format!("x11-input-events-{display}"))
+        .name(format!("x11-input-events-{}", connection.display()))
         .spawn(move || event_loop(event_dc))
         .map_err(|e| format!("spawn X11 event thread: {e}"))?;
     cache()
         .lock()
         .unwrap()
-        .insert(display.to_string(), dc.clone());
+        .insert(connection.clone(), dc.clone());
     Ok(dc)
 }
 
-fn connect(display: &str) -> Result<DisplayConn, String> {
-    let (conn, screen_num) = RustConnection::connect(Some(display))
-        .map_err(|e| format!("cannot connect to X display {display}: {e}"))?;
+fn connect(connection: &X11Connection) -> Result<DisplayConn, String> {
+    let (conn, screen_num) = connect_protocol(connection)?;
+    let display = connection.display();
     let setup = conn.setup();
     let min_keycode = setup.min_keycode;
     let max_keycode = setup.max_keycode;
@@ -202,6 +285,29 @@ fn connect(display: &str) -> Result<DisplayConn, String> {
     })
 }
 
+fn connect_protocol(connection: &X11Connection) -> Result<(RustConnection, usize), String> {
+    let display = connection.display();
+    match connection.authorization.as_ref() {
+        Some(authorization) => {
+            let display_id = parse_local_display_id(display)?;
+            let stream = UnixStream::connect(format!("/tmp/.X11-unix/X{display_id}"))
+                .map_err(|error| format!("cannot open X display {display} Unix socket: {error}"))?;
+            let (stream, _) = DefaultStream::from_unix_stream(stream)
+                .map_err(|error| format!("cannot prepare X display {display} stream: {error}"))?;
+            let connection = RustConnection::connect_to_stream_with_auth_info(
+                stream,
+                0,
+                authorization.protocol.clone(),
+                authorization.cookie.clone(),
+            )
+            .map_err(|error| format!("cannot authenticate to X display {display}: {error}"))?;
+            Ok((connection, 0))
+        }
+        None => RustConnection::connect(Some(display))
+            .map_err(|e| format!("cannot connect to X display {display}: {e}")),
+    }
+}
+
 fn intern_atom(conn: &RustConnection, name: &str) -> Result<xproto::Atom, String> {
     Ok(conn
         .intern_atom(false, name.as_bytes())
@@ -219,15 +325,23 @@ where
     T: Send + 'static,
     F: Fn(&DisplayConn) -> Result<T, OpError> + Send + Sync + 'static,
 {
-    let display = display.to_string();
+    with_connection(&X11Connection::unauthenticated(display), op).await
+}
+
+async fn with_connection<T, F>(connection: &X11Connection, op: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: Fn(&DisplayConn) -> Result<T, OpError> + Send + Sync + 'static,
+{
+    let connection = connection.clone();
     tokio::task::spawn_blocking(move || {
         let mut last_err = None;
         for attempt in 0..2 {
-            let dc = connect_cached(&display)?;
+            let dc = connect_cached(&connection)?;
             match op(&dc) {
                 Ok(v) => return Ok(v),
                 Err(OpError::Conn(e)) if attempt == 0 => {
-                    invalidate(&display);
+                    invalidate(&connection);
                     last_err = Some(e);
                 }
                 Err(OpError::Conn(e)) | Err(OpError::Other(e)) => return Err(e),
@@ -318,7 +432,16 @@ pub async fn click(display: &str, x: i32, y: i32, button: u8, clicks: u32) -> Re
 }
 
 pub async fn mouse_down(display: &str, x: i32, y: i32, button: u8) -> Result<(), String> {
-    with_conn(display, move |dc| {
+    mouse_down_on(&X11Connection::unauthenticated(display), x, y, button).await
+}
+
+pub async fn mouse_down_on(
+    connection: &X11Connection,
+    x: i32,
+    y: i32,
+    button: u8,
+) -> Result<(), String> {
+    with_connection(connection, move |dc| {
         fake_motion(dc, x, y)?;
         sync(dc)?;
         fake_button(dc, button, true)?;
@@ -329,7 +452,16 @@ pub async fn mouse_down(display: &str, x: i32, y: i32, button: u8) -> Result<(),
 }
 
 pub async fn mouse_up(display: &str, x: i32, y: i32, button: u8) -> Result<(), String> {
-    with_conn(display, move |dc| {
+    mouse_up_on(&X11Connection::unauthenticated(display), x, y, button).await
+}
+
+pub async fn mouse_up_on(
+    connection: &X11Connection,
+    x: i32,
+    y: i32,
+    button: u8,
+) -> Result<(), String> {
+    with_connection(connection, move |dc| {
         fake_motion(dc, x, y)?;
         sync(dc)?;
         fake_button(dc, button, false)?;
@@ -340,7 +472,11 @@ pub async fn mouse_up(display: &str, x: i32, y: i32, button: u8) -> Result<(), S
 }
 
 pub async fn move_mouse(display: &str, x: i32, y: i32) -> Result<(), String> {
-    with_conn(display, move |dc| {
+    move_mouse_on(&X11Connection::unauthenticated(display), x, y).await
+}
+
+pub async fn move_mouse_on(connection: &X11Connection, x: i32, y: i32) -> Result<(), String> {
+    with_connection(connection, move |dc| {
         fake_motion(dc, x, y)?;
         sync(dc)
     })
@@ -389,7 +525,24 @@ pub async fn drag(
 /// Scroll `amount` wheel ticks with the given X11 wheel button
 /// (4=up, 5=down, 6=left, 7=right).
 pub async fn scroll(display: &str, x: i32, y: i32, button: u8, amount: u32) -> Result<(), String> {
-    with_conn(display, move |dc| {
+    scroll_on(
+        &X11Connection::unauthenticated(display),
+        x,
+        y,
+        button,
+        amount,
+    )
+    .await
+}
+
+pub async fn scroll_on(
+    connection: &X11Connection,
+    x: i32,
+    y: i32,
+    button: u8,
+    amount: u32,
+) -> Result<(), String> {
+    with_connection(connection, move |dc| {
         fake_motion(dc, x, y)?;
         sync(dc)?;
         for i in 0..amount.max(1) {
@@ -409,7 +562,14 @@ pub async fn scroll(display: &str, x: i32, y: i32, button: u8, amount: u32) -> R
 /// the session backends. A mid-sequence failure releases any key left pressed
 /// before returning the error — a stuck modifier corrupts every later action.
 pub async fn key_sequence(display: &str, events: Vec<(String, bool)>) -> Result<(), String> {
-    with_conn(display, move |dc| {
+    key_sequence_on(&X11Connection::unauthenticated(display), events).await
+}
+
+pub async fn key_sequence_on(
+    connection: &X11Connection,
+    events: Vec<(String, bool)>,
+) -> Result<(), String> {
+    with_connection(connection, move |dc| {
         let mut outstanding: Vec<u8> = Vec::new();
         let mut result = Ok(());
         for (i, (code, press)) in events.iter().enumerate() {
@@ -544,8 +704,12 @@ fn build_keysym_index(dc: &DisplayConn) -> Result<KeysymIndex, OpError> {
 /// are pressed directly (with shift where needed); anything else goes through
 /// a scratch keycode temporarily remapped to the character's keysym.
 pub async fn type_text(display: &str, text: &str) -> Result<(), String> {
+    type_text_on(&X11Connection::unauthenticated(display), text).await
+}
+
+pub async fn type_text_on(connection: &X11Connection, text: &str) -> Result<(), String> {
     let text = text.to_string();
-    with_conn(display, move |dc| {
+    with_connection(connection, move |dc| {
         {
             let mut idx = dc.keysym_index.lock().unwrap();
             if idx.is_none() {
@@ -641,6 +805,10 @@ pub async fn type_text(display: &str, text: &str) -> Result<(), String> {
 /// selection keeps being served after this returns, like a normal clipboard
 /// owner, until another client takes the selection or the daemon exits.
 pub async fn paste(display: &str, text: &str) -> Result<(), String> {
+    paste_on(&X11Connection::unauthenticated(display), text).await
+}
+
+pub async fn paste_on(connection: &X11Connection, text: &str) -> Result<(), String> {
     if text.len() > PASTE_MAX_BYTES {
         return Err(format!(
             "paste text is {} bytes; the X11 direct-transfer limit is {} — use type or \
@@ -650,7 +818,7 @@ pub async fn paste(display: &str, text: &str) -> Result<(), String> {
         ));
     }
     let text = text.as_bytes().to_vec();
-    with_conn(display, move |dc| {
+    with_connection(connection, move |dc| {
         let _guard = dc.paste_lock.lock().unwrap();
         *dc.serving.lock().unwrap() = Some(ClipboardServing {
             text: Arc::new(text.clone()),
@@ -854,6 +1022,28 @@ mod tests {
         let text = "x".repeat(PASTE_MAX_BYTES + 1);
         let err = paste(":0", &text).await.unwrap_err();
         assert!(err.contains("direct-transfer limit"), "{err}");
+    }
+
+    #[test]
+    fn authenticated_connection_accepts_only_strict_local_display_and_cookie() {
+        let cookie = [7_u8; 16];
+        assert!(X11Connection::authenticated(":137", X11_AUTH_PROTOCOL, &cookie).is_ok());
+        for display in ["localhost:137", ":137.0", "137", ":", ":-1"] {
+            assert!(
+                X11Connection::authenticated(display, X11_AUTH_PROTOCOL, &cookie).is_err(),
+                "unsafe display unexpectedly accepted: {display}"
+            );
+        }
+        assert!(X11Connection::authenticated(":137", b"XDM-AUTHORIZATION-1", &cookie).is_err());
+        assert!(X11Connection::authenticated(":137", X11_AUTH_PROTOCOL, &[7_u8; 15]).is_err());
+    }
+
+    #[test]
+    fn connection_cache_identity_includes_authorization() {
+        let first = X11Connection::authenticated(":137", X11_AUTH_PROTOCOL, &[1_u8; 16]).unwrap();
+        let replacement =
+            X11Connection::authenticated(":137", X11_AUTH_PROTOCOL, &[2_u8; 16]).unwrap();
+        assert!(first != replacement);
     }
 
     /// Live test — needs a reachable X server (DISPLAY or :0). Run on the

--- a/crates/intendant-platform/Cargo.toml
+++ b/crates/intendant-platform/Cargo.toml
@@ -20,6 +20,9 @@ tempfile = "3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+tempfile = "3"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",

--- a/crates/intendant-platform/examples/private-xvfb-auth-smoke.rs
+++ b/crates/intendant-platform/examples/private-xvfb-auth-smoke.rs
@@ -1,0 +1,78 @@
+//! Manual live acceptance smoke for Intendant's private Xvfb boundary.
+//!
+//! This is deliberately an example rather than a Rust test: it inspects the
+//! host's real X11 namespace, launches installed binaries, and must never run
+//! as part of the repository's hermetic unit suite.
+
+#[cfg(target_os = "linux")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    use intendant_platform::{vision, DisplayTarget};
+    use std::process::Stdio;
+
+    let mut excluded = Vec::new();
+    let config = loop {
+        let config =
+            vision::virtual_display_config(640, 480, &excluded).expect("no free managed X display");
+        let DisplayTarget::Virtual { id } = config.target else {
+            panic!("virtual display allocator returned the user session");
+        };
+        let tcp = std::net::SocketAddr::from(([127, 0, 0, 1], 6000 + id as u16));
+        if std::net::TcpStream::connect_timeout(&tcp, std::time::Duration::from_millis(50)).is_err()
+        {
+            break config;
+        }
+        excluded.push(id);
+    };
+    let DisplayTarget::Virtual { id } = config.target else {
+        unreachable!();
+    };
+    let guard = vision::launch_private_display(&config)
+        .await
+        .expect("launch private Xvfb");
+    let authorization =
+        vision::virtual_display_x11_authorization(id).expect("live X11 authorization");
+    let display = format!(":{id}");
+
+    let unauthorized = tokio::process::Command::new("xdpyinfo")
+        .args(["-display", &display])
+        .env_remove("XAUTHORITY")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .expect("run unauthenticated xdpyinfo");
+    assert!(
+        !unauthorized.success(),
+        "unauthenticated X11 access succeeded"
+    );
+
+    let authorized = tokio::process::Command::new("xdpyinfo")
+        .args(["-display", &display])
+        .env("XAUTHORITY", authorization.xauthority_path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .expect("run authenticated xdpyinfo");
+    assert!(authorized.success(), "authenticated X11 access failed");
+
+    let tcp = std::net::SocketAddr::from(([127, 0, 0, 1], 6000 + id as u16));
+    assert!(
+        std::net::TcpStream::connect_timeout(&tcp, std::time::Duration::from_millis(100)).is_err(),
+        "private Xvfb unexpectedly exposed TCP port {}",
+        tcp.port()
+    );
+
+    let credential_path = authorization.xauthority_path().to_path_buf();
+    guard.shutdown().await;
+    assert!(vision::virtual_display_x11_authorization(id).is_none());
+    assert!(!credential_path.exists(), "Xauthority survived teardown");
+    println!("private Xvfb authorization smoke passed on {display}");
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("private Xvfb authorization smoke is Linux-only");
+    std::process::exit(2);
+}

--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -2337,14 +2337,6 @@ mod owner_private_acl {
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
-    #[test]
-    fn local_hostname_bytes_are_nonempty_and_nul_free() {
-        let hostname = local_hostname_bytes().expect("Unix host must expose its hostname");
-        assert!(!hostname.is_empty());
-        assert!(!hostname.contains(&0));
-    }
-
     #[test]
     fn path_leaf_link_probe_accepts_real_entries() {
         let temp = tempfile::tempdir().unwrap();

--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -140,6 +140,43 @@ pub fn request_graceful_terminate(pid: u32) -> bool {
     }
 }
 
+/// Return this host's native hostname bytes for local operating-system
+/// protocols such as Xauthority. The bytes exclude the terminating NUL.
+///
+/// Keeping the FFI here preserves `platform.rs` as the Unix unsafe-code
+/// island; callers receive an ordinary safe Rust result.
+pub fn local_hostname_bytes() -> std::io::Result<Vec<u8>> {
+    #[cfg(unix)]
+    {
+        let mut bytes = [0_u8; 256];
+        // SAFETY: `bytes` is writable for its full declared length.
+        // gethostname writes at most that many bytes and retains no pointer.
+        if unsafe { libc::gethostname(bytes.as_mut_ptr().cast(), bytes.len()) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let end = bytes.iter().position(|byte| *byte == 0).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "local hostname exceeded the operating-system buffer",
+            )
+        })?;
+        if end == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "local hostname is empty",
+            ));
+        }
+        Ok(bytes[..end].to_vec())
+    }
+    #[cfg(not(unix))]
+    {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "native hostname bytes are unavailable on this platform",
+        ))
+    }
+}
+
 /// Create a FIFO for Unix-only lock-file regression tests. Keeping this tiny
 /// wrapper here preserves `platform.rs` as the crate's documented unsafe
 /// island; production code never calls it.
@@ -2299,6 +2336,14 @@ mod owner_private_acl {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn local_hostname_bytes_are_nonempty_and_nul_free() {
+        let hostname = local_hostname_bytes().expect("Unix host must expose its hostname");
+        assert!(!hostname.is_empty());
+        assert!(!hostname.contains(&0));
+    }
 
     #[test]
     fn path_leaf_link_probe_accepts_real_entries() {

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -519,6 +519,42 @@ fn encode_xauthority_record(
 fn create_private_x11_authorization(
     display_id: u32,
 ) -> Result<PrivateX11Authorization, CallerError> {
+    let hostname = crate::platform::local_hostname_bytes().map_err(|error| {
+        CallerError::Config(format!(
+            "Failed to read local hostname for Xauthority: {error}"
+        ))
+    })?;
+    let mut cookie = vec![0_u8; 16];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut random| random.read_exact(&mut cookie))
+        .map_err(|error| {
+            CallerError::Config(format!("Failed to generate Xauthority cookie: {error}"))
+        })?;
+    create_private_x11_authorization_from_parts(
+        display_id,
+        &hostname,
+        cookie,
+        &std::env::temp_dir(),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn create_private_x11_authorization_from_parts(
+    display_id: u32,
+    hostname: &[u8],
+    cookie: Vec<u8>,
+    temp_root: &std::path::Path,
+) -> Result<PrivateX11Authorization, CallerError> {
+    if hostname.is_empty() || hostname.contains(&0) {
+        return Err(CallerError::Config(
+            "Xauthority hostname must be nonempty and NUL-free".to_string(),
+        ));
+    }
+    if cookie.len() != 16 {
+        return Err(CallerError::Config(
+            "MIT-MAGIC-COOKIE-1 data must contain exactly 16 bytes".to_string(),
+        ));
+    }
     let directory = tempfile::Builder::new()
         .prefix("intendant-xauthority-")
         // `tempfile` defaults directories to 0777 masked by the host umask;
@@ -526,7 +562,7 @@ fn create_private_x11_authorization(
         // creation time. Supplying 0700 reaches mkdir(2) atomically and the
         // umask may only make it more restrictive.
         .permissions(std::fs::Permissions::from_mode(0o700))
-        .tempdir()
+        .tempdir_in(temp_root)
         .map_err(|error| {
             CallerError::Config(format!(
                 "Failed to create private Xauthority directory: {error}"
@@ -547,18 +583,7 @@ fn create_private_x11_authorization(
         )));
     }
 
-    let mut cookie = vec![0_u8; 16];
-    std::fs::File::open("/dev/urandom")
-        .and_then(|mut random| random.read_exact(&mut cookie))
-        .map_err(|error| {
-            CallerError::Config(format!("Failed to generate Xauthority cookie: {error}"))
-        })?;
-    let hostname = crate::platform::local_hostname_bytes().map_err(|error| {
-        CallerError::Config(format!(
-            "Failed to read local hostname for Xauthority: {error}"
-        ))
-    })?;
-    let record = encode_xauthority_record(display_id, &hostname, &cookie)?;
+    let record = encode_xauthority_record(display_id, hostname, &cookie)?;
     let path = directory.path().join("Xauthority");
     let mut file = std::fs::OpenOptions::new()
         .write(true)
@@ -1068,7 +1093,14 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn private_xauthority_is_mode_restricted_and_ephemeral() {
-        let authorization = create_private_x11_authorization(137).unwrap();
+        let temp_root = tempfile::tempdir().unwrap();
+        let authorization = create_private_x11_authorization_from_parts(
+            137,
+            b"fixture-host",
+            vec![7_u8; 16],
+            temp_root.path(),
+        )
+        .unwrap();
         let path = authorization.authorization.xauthority_path().to_path_buf();
         assert_eq!(
             std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
@@ -1078,67 +1110,6 @@ mod tests {
         assert_eq!(authorization.authorization.cookie().len(), 16);
         drop(authorization);
         assert!(!path.exists());
-    }
-
-    /// Live acceptance test for the real Xvfb authorization boundary. Run on
-    /// Linux capture hosts with both `Xvfb` and `xdpyinfo` installed.
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    #[ignore]
-    async fn live_private_xvfb_rejects_unauthenticated_clients_and_tcp() {
-        let mut excluded = Vec::new();
-        let config = loop {
-            let config = virtual_display_config(640, 480, &excluded).expect("free display");
-            let DisplayTarget::Virtual { id } = config.target else {
-                panic!("virtual display allocator returned the user session");
-            };
-            let tcp = std::net::SocketAddr::from(([127, 0, 0, 1], 6000 + id as u16));
-            if std::net::TcpStream::connect_timeout(&tcp, std::time::Duration::from_millis(50))
-                .is_err()
-            {
-                break config;
-            }
-            excluded.push(id);
-        };
-        let DisplayTarget::Virtual { id } = config.target else {
-            unreachable!();
-        };
-        let guard = launch_private_display(&config).await.expect("private Xvfb");
-        let authorization = virtual_display_x11_authorization(id).expect("live authorization");
-        let display = format!(":{id}");
-
-        let unauthorized = tokio::process::Command::new("xdpyinfo")
-            .args(["-display", &display])
-            .env_remove("XAUTHORITY")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .expect("unauthenticated xdpyinfo");
-        assert!(!unauthorized.success());
-
-        let authorized = tokio::process::Command::new("xdpyinfo")
-            .args(["-display", &display])
-            .env("XAUTHORITY", authorization.xauthority_path())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .expect("authenticated xdpyinfo");
-        assert!(authorized.success());
-
-        let tcp = std::net::SocketAddr::from(([127, 0, 0, 1], 6000 + id as u16));
-        assert!(
-            std::net::TcpStream::connect_timeout(&tcp, std::time::Duration::from_millis(100))
-                .is_err(),
-            "private Xvfb unexpectedly exposed TCP port {}",
-            tcp.port()
-        );
-
-        let credential_path = authorization.xauthority_path().to_path_buf();
-        guard.shutdown().await;
-        assert!(virtual_display_x11_authorization(id).is_none());
-        assert!(!credential_path.exists());
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -487,30 +487,6 @@ impl Drop for XvfbGuard {
 const X11_AUTH_PROTOCOL: &[u8] = b"MIT-MAGIC-COOKIE-1";
 
 #[cfg(target_os = "linux")]
-fn local_hostname() -> Result<Vec<u8>, CallerError> {
-    let mut bytes = [0_u8; 256];
-    // SAFETY: `bytes` is writable for its full declared length. gethostname
-    // writes at most that many bytes and retains no pointer.
-    if unsafe { libc::gethostname(bytes.as_mut_ptr().cast(), bytes.len()) } != 0 {
-        return Err(CallerError::Config(format!(
-            "Failed to read local hostname for Xauthority: {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-    let Some(end) = bytes.iter().position(|byte| *byte == 0) else {
-        return Err(CallerError::Config(
-            "Local hostname exceeded the Xauthority buffer".to_string(),
-        ));
-    };
-    if end == 0 {
-        return Err(CallerError::Config(
-            "Local hostname is empty; cannot create Xauthority".to_string(),
-        ));
-    }
-    Ok(bytes[..end].to_vec())
-}
-
-#[cfg(target_os = "linux")]
 fn append_xauthority_field(record: &mut Vec<u8>, value: &[u8]) -> Result<(), CallerError> {
     let length = u16::try_from(value.len()).map_err(|_| {
         CallerError::Config("Xauthority field exceeded the 16-bit format limit".to_string())
@@ -577,7 +553,12 @@ fn create_private_x11_authorization(
         .map_err(|error| {
             CallerError::Config(format!("Failed to generate Xauthority cookie: {error}"))
         })?;
-    let record = encode_xauthority_record(display_id, &local_hostname()?, &cookie)?;
+    let hostname = crate::platform::local_hostname_bytes().map_err(|error| {
+        CallerError::Config(format!(
+            "Failed to read local hostname for Xauthority: {error}"
+        ))
+    })?;
+    let record = encode_xauthority_record(display_id, &hostname, &cookie)?;
     let path = directory.path().join("Xauthority");
     let mut file = std::fs::OpenOptions::new()
         .write(true)

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -2,9 +2,9 @@ use intendant_core::error::CallerError;
 #[cfg(target_os = "linux")]
 use std::collections::HashMap;
 #[cfg(target_os = "linux")]
-use std::io::Read as _;
+use std::io::{Read as _, Write as _};
 #[cfg(target_os = "linux")]
-use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
+use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _, PermissionsExt as _};
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
 #[cfg(target_os = "linux")]
@@ -134,10 +134,51 @@ const PREFERRED_DISPLAY: u32 = 99;
 const VIRTUAL_DISPLAY_END: u32 = 200;
 
 #[cfg(target_os = "linux")]
-static OWNED_XVFB_PROCESSES: OnceLock<Mutex<HashMap<u32, u32>>> = OnceLock::new();
+static OWNED_XVFB_PROCESSES: OnceLock<Mutex<HashMap<u32, OwnedXvfbProcess>>> = OnceLock::new();
 
 #[cfg(target_os = "linux")]
-fn owned_xvfb_processes() -> &'static Mutex<HashMap<u32, u32>> {
+#[derive(Clone)]
+struct OwnedXvfbProcess {
+    pid: u32,
+    authorization: Option<X11Authorization>,
+}
+
+#[cfg(target_os = "linux")]
+struct PrivateX11Authorization {
+    authorization: X11Authorization,
+    _directory: tempfile::TempDir,
+}
+
+/// Daemon-held credentials for one Intendant-owned X11 display.
+///
+/// This value is intentionally not serializable. It may be passed only to
+/// in-process display clients and to the exact browser child bound to this
+/// display; portable receipts must never contain either field.
+#[cfg(target_os = "linux")]
+#[derive(Clone, PartialEq, Eq)]
+pub struct X11Authorization {
+    xauthority_path: std::path::PathBuf,
+    protocol: Vec<u8>,
+    cookie: Vec<u8>,
+}
+
+#[cfg(target_os = "linux")]
+impl X11Authorization {
+    pub fn xauthority_path(&self) -> &std::path::Path {
+        &self.xauthority_path
+    }
+
+    pub fn protocol(&self) -> &[u8] {
+        &self.protocol
+    }
+
+    pub fn cookie(&self) -> &[u8] {
+        &self.cookie
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn owned_xvfb_processes() -> &'static Mutex<HashMap<u32, OwnedXvfbProcess>> {
     OWNED_XVFB_PROCESSES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -155,13 +196,19 @@ pub fn managed_virtual_display_id(display_id: u32) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn register_owned_xvfb(display_id: u32, pid: u32) -> Result<(), CallerError> {
+fn register_owned_xvfb(
+    display_id: u32,
+    pid: u32,
+    authorization: Option<X11Authorization>,
+) -> Result<(), CallerError> {
     let mut owned = owned_xvfb_processes()
         .lock()
         .map_err(|_| CallerError::Config("owned Xvfb registry is unavailable".to_string()))?;
-    if let Some(existing_pid) = owned.insert(display_id, pid) {
-        if existing_pid != pid {
-            owned.insert(display_id, existing_pid);
+    let owned_process = OwnedXvfbProcess { pid, authorization };
+    if let Some(existing) = owned.insert(display_id, owned_process) {
+        if existing.pid != pid {
+            let existing_pid = existing.pid;
+            owned.insert(display_id, existing);
             return Err(CallerError::Config(format!(
                 "display :{display_id} is already owned by Xvfb process {existing_pid}"
             )));
@@ -173,7 +220,7 @@ fn register_owned_xvfb(display_id: u32, pid: u32) -> Result<(), CallerError> {
 #[cfg(target_os = "linux")]
 fn unregister_owned_xvfb(display_id: u32, pid: u32) {
     if let Ok(mut owned) = owned_xvfb_processes().lock() {
-        if owned.get(&display_id) == Some(&pid) {
+        if owned.get(&display_id).is_some_and(|owned| owned.pid == pid) {
             owned.remove(&display_id);
         }
     }
@@ -191,7 +238,7 @@ pub fn process_owns_virtual_display(display_id: u32) -> bool {
         let pid = owned_xvfb_processes()
             .lock()
             .ok()
-            .and_then(|owned| owned.get(&display_id).copied());
+            .and_then(|owned| owned.get(&display_id).map(|owned| owned.pid));
         pid.is_some_and(|pid| {
             crate::platform::process_alive(pid)
                 && xvfb_state_established(std::path::Path::new("/tmp"), display_id, pid)
@@ -202,6 +249,23 @@ pub fn process_owns_virtual_display(display_id: u32) -> bool {
         let _ = display_id;
         false
     }
+}
+
+/// Return the private X11 authorization for a live display owned by this
+/// process. Generic `-ac` agent-loop displays deliberately return `None`.
+#[cfg(target_os = "linux")]
+pub fn virtual_display_x11_authorization(display_id: u32) -> Option<X11Authorization> {
+    if !managed_virtual_display_id(display_id) {
+        return None;
+    }
+    let owned = owned_xvfb_processes().lock().ok()?;
+    let process = owned.get(&display_id)?;
+    if !crate::platform::process_alive(process.pid)
+        || !xvfb_state_established(std::path::Path::new("/tmp"), display_id, process.pid)
+    {
+        return None;
+    }
+    process.authorization.clone()
 }
 
 /// Find a free X display number, preferring :99.
@@ -333,6 +397,8 @@ pub struct XvfbGuard {
     display_id: u32,
     #[cfg(target_os = "linux")]
     pid: u32,
+    #[cfg(target_os = "linux")]
+    _authorization: Option<PrivateX11Authorization>,
 }
 
 impl XvfbGuard {
@@ -417,6 +483,133 @@ impl Drop for XvfbGuard {
 
 // ── Display launch (Linux / X11) ────────────────────────────────────────────
 
+#[cfg(target_os = "linux")]
+const X11_AUTH_PROTOCOL: &[u8] = b"MIT-MAGIC-COOKIE-1";
+
+#[cfg(target_os = "linux")]
+fn local_hostname() -> Result<Vec<u8>, CallerError> {
+    let mut bytes = [0_u8; 256];
+    // SAFETY: `bytes` is writable for its full declared length. gethostname
+    // writes at most that many bytes and retains no pointer.
+    if unsafe { libc::gethostname(bytes.as_mut_ptr().cast(), bytes.len()) } != 0 {
+        return Err(CallerError::Config(format!(
+            "Failed to read local hostname for Xauthority: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    let Some(end) = bytes.iter().position(|byte| *byte == 0) else {
+        return Err(CallerError::Config(
+            "Local hostname exceeded the Xauthority buffer".to_string(),
+        ));
+    };
+    if end == 0 {
+        return Err(CallerError::Config(
+            "Local hostname is empty; cannot create Xauthority".to_string(),
+        ));
+    }
+    Ok(bytes[..end].to_vec())
+}
+
+#[cfg(target_os = "linux")]
+fn append_xauthority_field(record: &mut Vec<u8>, value: &[u8]) -> Result<(), CallerError> {
+    let length = u16::try_from(value.len()).map_err(|_| {
+        CallerError::Config("Xauthority field exceeded the 16-bit format limit".to_string())
+    })?;
+    record.extend_from_slice(&length.to_be_bytes());
+    record.extend_from_slice(value);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn encode_xauthority_record(
+    display_id: u32,
+    hostname: &[u8],
+    cookie: &[u8],
+) -> Result<Vec<u8>, CallerError> {
+    const FAMILY_LOCAL: u16 = 256;
+    let display = display_id.to_string();
+    let mut record = Vec::with_capacity(
+        2 + 2 + hostname.len() + 2 + display.len() + 2 + X11_AUTH_PROTOCOL.len() + 2 + cookie.len(),
+    );
+    record.extend_from_slice(&FAMILY_LOCAL.to_be_bytes());
+    append_xauthority_field(&mut record, hostname)?;
+    append_xauthority_field(&mut record, display.as_bytes())?;
+    append_xauthority_field(&mut record, X11_AUTH_PROTOCOL)?;
+    append_xauthority_field(&mut record, cookie)?;
+    Ok(record)
+}
+
+#[cfg(target_os = "linux")]
+fn create_private_x11_authorization(
+    display_id: u32,
+) -> Result<PrivateX11Authorization, CallerError> {
+    let directory = tempfile::Builder::new()
+        .prefix("intendant-xauthority-")
+        .tempdir()
+        .map_err(|error| {
+            CallerError::Config(format!(
+                "Failed to create private Xauthority directory: {error}"
+            ))
+        })?;
+    let directory_mode = directory
+        .path()
+        .metadata()
+        .map_err(|error| {
+            CallerError::Config(format!("Failed to inspect Xauthority directory: {error}"))
+        })?
+        .permissions()
+        .mode()
+        & 0o777;
+    if directory_mode != 0o700 {
+        return Err(CallerError::Config(format!(
+            "Private Xauthority directory has unsafe mode {directory_mode:o}"
+        )));
+    }
+
+    let mut cookie = vec![0_u8; 16];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut random| random.read_exact(&mut cookie))
+        .map_err(|error| {
+            CallerError::Config(format!("Failed to generate Xauthority cookie: {error}"))
+        })?;
+    let record = encode_xauthority_record(display_id, &local_hostname()?, &cookie)?;
+    let path = directory.path().join("Xauthority");
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .map_err(|error| {
+            CallerError::Config(format!("Failed to create private Xauthority file: {error}"))
+        })?;
+    file.write_all(&record)
+        .and_then(|()| file.sync_all())
+        .map_err(|error| {
+            CallerError::Config(format!(
+                "Failed to persist private Xauthority file: {error}"
+            ))
+        })?;
+    let metadata = file.metadata().map_err(|error| {
+        CallerError::Config(format!(
+            "Failed to inspect private Xauthority file: {error}"
+        ))
+    })?;
+    if !metadata.file_type().is_file() || metadata.permissions().mode() & 0o777 != 0o600 {
+        return Err(CallerError::Config(
+            "Private Xauthority file is not a mode-0600 regular file".to_string(),
+        ));
+    }
+
+    Ok(PrivateX11Authorization {
+        authorization: X11Authorization {
+            xauthority_path: path,
+            protocol: X11_AUTH_PROTOCOL.to_vec(),
+            cookie,
+        },
+        _directory: directory,
+    })
+}
+
 /// Launch Xvfb on the given display with the given resolution.
 /// The config's target must be `DisplayTarget::Virtual`; returns
 /// `CallerError::Config` otherwise.
@@ -426,6 +619,30 @@ impl Drop for XvfbGuard {
 /// browser subprocesses.
 #[cfg(target_os = "linux")]
 pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerError> {
+    launch_display_with_authorization(config, None).await
+}
+
+/// Launch an Xvfb whose Unix socket requires a fresh private per-display
+/// MIT-MAGIC-COOKIE and whose TCP listener is disabled.
+#[cfg(target_os = "linux")]
+pub async fn launch_private_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerError> {
+    let display_id = match config.target {
+        DisplayTarget::Virtual { id } => id,
+        DisplayTarget::UserSession => {
+            return Err(CallerError::Config(
+                "Cannot launch Xvfb for the user session display".to_string(),
+            ))
+        }
+    };
+    let authorization = create_private_x11_authorization(display_id)?;
+    launch_display_with_authorization(config, Some(authorization)).await
+}
+
+#[cfg(target_os = "linux")]
+async fn launch_display_with_authorization(
+    config: &DisplayConfig,
+    authorization: Option<PrivateX11Authorization>,
+) -> Result<XvfbGuard, CallerError> {
     let display_id = match config.target {
         DisplayTarget::Virtual { id } => id,
         DisplayTarget::UserSession => {
@@ -437,8 +654,18 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
     let display_arg = format!(":{}", display_id);
     let screen_arg = format!("{}x{}x24", config.width, config.height);
 
-    let mut child = tokio::process::Command::new("Xvfb")
-        .args([&display_arg, "-screen", "0", &screen_arg, "-ac"])
+    let mut command = tokio::process::Command::new("Xvfb");
+    command
+        .args([&display_arg, "-screen", "0", &screen_arg])
+        .args(["-nolisten", "tcp"]);
+    if let Some(authorization) = authorization.as_ref() {
+        command
+            .arg("-auth")
+            .arg(authorization.authorization.xauthority_path());
+    } else {
+        command.arg("-ac");
+    }
+    let mut child = command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -452,12 +679,15 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // Verify the display is accessible
-    let check = tokio::process::Command::new("xdpyinfo")
+    let mut check_command = tokio::process::Command::new("xdpyinfo");
+    check_command
         .args(["-display", &display_arg])
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await;
+        .stderr(Stdio::null());
+    if let Some(authorization) = authorization.as_ref() {
+        check_command.env("XAUTHORITY", authorization.authorization.xauthority_path());
+    }
+    let check = check_command.status().await;
 
     if check.map(|s| !s.success()).unwrap_or(true) {
         return Err(CallerError::Config(format!(
@@ -485,12 +715,19 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
             "Xvfb on display {display_arg} did not establish its expected lock and socket"
         )));
     }
-    register_owned_xvfb(display_id, pid)?;
+    register_owned_xvfb(
+        display_id,
+        pid,
+        authorization
+            .as_ref()
+            .map(|authorization| authorization.authorization.clone()),
+    )?;
 
     Ok(XvfbGuard {
         child,
         display_id,
         pid,
+        _authorization: authorization,
     })
 }
 
@@ -499,6 +736,13 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
 pub async fn launch_display(_config: &DisplayConfig) -> Result<XvfbGuard, CallerError> {
     Err(CallerError::Config(
         "Virtual display launch is only available on Linux".into(),
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn launch_private_display(_config: &DisplayConfig) -> Result<XvfbGuard, CallerError> {
+    Err(CallerError::Config(
+        "Private virtual display launch is only available on Linux".into(),
     ))
 }
 
@@ -793,18 +1037,61 @@ mod tests {
 
         let display_id = VIRTUAL_DISPLAY_END - 1;
         unregister_owned_xvfb(display_id, 41_001);
-        register_owned_xvfb(display_id, 41_001).unwrap();
-        assert!(register_owned_xvfb(display_id, 41_002).is_err());
+        register_owned_xvfb(display_id, 41_001, None).unwrap();
+        assert!(register_owned_xvfb(display_id, 41_002, None).is_err());
         unregister_owned_xvfb(display_id, 41_002);
         assert_eq!(
-            owned_xvfb_processes().lock().unwrap().get(&display_id),
-            Some(&41_001)
+            owned_xvfb_processes()
+                .lock()
+                .unwrap()
+                .get(&display_id)
+                .map(|process| process.pid),
+            Some(41_001)
         );
         unregister_owned_xvfb(display_id, 41_001);
         assert!(!owned_xvfb_processes()
             .lock()
             .unwrap()
             .contains_key(&display_id));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn xauthority_record_is_binary_safe_and_display_scoped() {
+        let hostname = b"capture-host";
+        let cookie = [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 254, 255];
+        let record = encode_xauthority_record(137, hostname, &cookie).unwrap();
+
+        fn take_field<'a>(record: &'a [u8], cursor: &mut usize) -> &'a [u8] {
+            let length = u16::from_be_bytes([record[*cursor], record[*cursor + 1]]) as usize;
+            *cursor += 2;
+            let field = &record[*cursor..*cursor + length];
+            *cursor += length;
+            field
+        }
+
+        assert_eq!(u16::from_be_bytes([record[0], record[1]]), 256);
+        let mut cursor = 2;
+        assert_eq!(take_field(&record, &mut cursor), hostname);
+        assert_eq!(take_field(&record, &mut cursor), b"137");
+        assert_eq!(take_field(&record, &mut cursor), X11_AUTH_PROTOCOL);
+        assert_eq!(take_field(&record, &mut cursor), cookie);
+        assert_eq!(cursor, record.len());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn private_xauthority_is_mode_restricted_and_ephemeral() {
+        let authorization = create_private_x11_authorization(137).unwrap();
+        let path = authorization.authorization.xauthority_path().to_path_buf();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(authorization.authorization.protocol(), X11_AUTH_PROTOCOL);
+        assert_eq!(authorization.authorization.cookie().len(), 16);
+        drop(authorization);
+        assert!(!path.exists());
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -545,6 +545,11 @@ fn create_private_x11_authorization(
 ) -> Result<PrivateX11Authorization, CallerError> {
     let directory = tempfile::Builder::new()
         .prefix("intendant-xauthority-")
+        // `tempfile` defaults directories to 0777 masked by the host umask;
+        // a group-friendly umask can therefore expose the pathname at
+        // creation time. Supplying 0700 reaches mkdir(2) atomically and the
+        // umask may only make it more restrictive.
+        .permissions(std::fs::Permissions::from_mode(0o700))
         .tempdir()
         .map_err(|error| {
             CallerError::Config(format!(

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -1099,6 +1099,67 @@ mod tests {
         assert!(!path.exists());
     }
 
+    /// Live acceptance test for the real Xvfb authorization boundary. Run on
+    /// Linux capture hosts with both `Xvfb` and `xdpyinfo` installed.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[ignore]
+    async fn live_private_xvfb_rejects_unauthenticated_clients_and_tcp() {
+        let mut excluded = Vec::new();
+        let config = loop {
+            let config = virtual_display_config(640, 480, &excluded).expect("free display");
+            let DisplayTarget::Virtual { id } = config.target else {
+                panic!("virtual display allocator returned the user session");
+            };
+            let tcp = std::net::SocketAddr::from(([127, 0, 0, 1], 6000 + id as u16));
+            if std::net::TcpStream::connect_timeout(&tcp, std::time::Duration::from_millis(50))
+                .is_err()
+            {
+                break config;
+            }
+            excluded.push(id);
+        };
+        let DisplayTarget::Virtual { id } = config.target else {
+            unreachable!();
+        };
+        let guard = launch_private_display(&config).await.expect("private Xvfb");
+        let authorization = virtual_display_x11_authorization(id).expect("live authorization");
+        let display = format!(":{id}");
+
+        let unauthorized = tokio::process::Command::new("xdpyinfo")
+            .args(["-display", &display])
+            .env_remove("XAUTHORITY")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .expect("unauthenticated xdpyinfo");
+        assert!(!unauthorized.success());
+
+        let authorized = tokio::process::Command::new("xdpyinfo")
+            .args(["-display", &display])
+            .env("XAUTHORITY", authorization.xauthority_path())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .expect("authenticated xdpyinfo");
+        assert!(authorized.success());
+
+        let tcp = std::net::SocketAddr::from(([127, 0, 0, 1], 6000 + id as u16));
+        assert!(
+            std::net::TcpStream::connect_timeout(&tcp, std::time::Duration::from_millis(100))
+                .is_err(),
+            "private Xvfb unexpectedly exposed TCP port {}",
+            tcp.port()
+        );
+
+        let credential_path = authorization.xauthority_path().to_path_buf();
+        guard.shutdown().await;
+        assert!(virtual_display_x11_authorization(id).is_none());
+        assert!(!credential_path.exists());
+    }
+
     #[cfg(not(target_os = "linux"))]
     #[test]
     fn virtual_display_socket_probe_is_linux_only() {

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -347,7 +347,7 @@ claim instead.
 | Tool                 | Description | Params |
 |----------------------|-------------|--------|
 | `list_displays`      | Enumerate displays with their session state. | — |
-| `create_virtual_display` | Create a daemon-owned virtual display (Xvfb) and activate it for capture and streaming; it announces as `display_ready` to every dashboard and federated peer. The display survives the calling session and dies with the daemon; closing its dashboard tile (or revoking its id) reaps it early. Linux hosts only today — other platforms report a clear error. | `width?`, `height?` |
+| `create_virtual_display` | Create a daemon-owned virtual display (Xvfb) and activate it for capture and streaming; it announces as `display_ready` to every dashboard and federated peer. On Linux, each dashboard-created display has a fresh daemon-held Xauthority cookie and no X11 TCP listener; capture, input, and its bound browser authenticate explicitly. The display survives the calling session and dies with the daemon; closing its dashboard tile (or revoking its id) reaps it early. Linux hosts only today — other platforms report a clear error. | `width?`, `height?` |
 | `take_display`       | Optional dashboard signal that an agent is using a display; it neither grants input authority nor is required before screenshot/CU calls. | `display_id` |
 | `release_display`    | Release control of a display. | `display_id`, `note?` |
 | `grant_user_display` | Grant access to the user's real display session (owner surfaces only — this call *is* the opt-in); on Wayland, enable **Allow Remote Interaction** in the GNOME portal before clicking **Share** so CU input works. | `display_id?` |
@@ -412,8 +412,10 @@ active holder. On Linux, `display_target` can bind a local CDP workspace to a
 virtual display returned by this daemon's `create_virtual_display` tool (for
 example, `display_99`). Intendant rejects user-session, session-local,
 out-of-range, and foreign X servers. It reserves the binding before launch,
-rechecks its lifecycle before promotion, and retires the browser when that
-display is destroyed.
+waits for authenticated capture readiness before admitting a browser, rechecks
+the display lifecycle before promotion, and retires the browser when that
+display is destroyed. The Xauthority path and cookie remain runtime-only and
+are never included in workspace records or portable evidence receipts.
 
 | Tool                          | Description | Params |
 |-------------------------------|-------------|--------|

--- a/docs/src/runtime-protocol.md
+++ b/docs/src/runtime-protocol.md
@@ -218,6 +218,11 @@ one. `replace_lines` errors if `end_line < line_number`.
   The controller derives that variable onto the runtime child's environment at
   spawn time from the autonomy guard's `user_display_granted` (the grant's
   single source of truth) — it is never set on the controller's own process.
+  For a daemon-owned private Xvfb, the controller also resolves that exact
+  display's live Xauthority path and injects a display-scoped internal record
+  over the runtime's one-shot stdin. Any model-supplied record is discarded;
+  `execAsAgent` and `captureScreen` select only the credential matching their
+  chosen display, while ordinary displays retain the merged session credential.
 - **Exit codes**: real exit code on completion; `-3` on timeout (process killed),
   `-2` on `wait_for_port` timeout, `-1` on spawn/wait failure.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,7 @@
 use crate::error::AgentError;
-use crate::models::{AgentInput, Command as AgentCommand, ProcessInfo, ProcessStatus};
+use crate::models::{
+    AgentInput, Command as AgentCommand, ProcessInfo, ProcessStatus, RuntimeX11Authorization,
+};
 // `MetadataExt` exposes the POSIX `mode`/`uid`/`gid` accessors used by
 // `inspectPath`. They don't exist on Windows metadata, so the import (and
 // the fields it powers) are gated to Unix; the Windows arm of the
@@ -261,6 +263,10 @@ pub struct Agent {
     pty_sessions: Arc<tokio::sync::Mutex<HashMap<String, PtySession>>>,
     available_displays: Vec<i32>,
     session_xauthority: Option<PathBuf>,
+    /// Controller-authenticated, batch-scoped authorization paths for
+    /// daemon-owned private displays. Unlike `session_xauthority`, these do
+    /// not come from ambient account or display-manager state.
+    runtime_x11_authorities: HashMap<i32, PathBuf>,
     /// Restriction-only mode minted by the controller for the OS-free mock
     /// display rig. It disables every runtime path that can discover, select,
     /// authenticate to, or capture a native display.
@@ -285,6 +291,7 @@ impl Agent {
             pty_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             available_displays: vec![],
             session_xauthority: None,
+            runtime_x11_authorities: HashMap::new(),
             synthetic_display_runtime: false,
             human_response_token: None,
             runtime_protocol_token: None,
@@ -311,6 +318,7 @@ impl Agent {
             pty_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             available_displays,
             session_xauthority,
+            runtime_x11_authorities: HashMap::new(),
             synthetic_display_runtime,
             human_response_token: None,
             runtime_protocol_token: None,
@@ -350,6 +358,33 @@ impl Agent {
     pub fn with_runtime_protocol_token(mut self, token: Option<String>) -> Self {
         self.runtime_protocol_token = token;
         self
+    }
+
+    /// Adopt controller-selected private-display authorization paths for this
+    /// one runtime batch. Invalid/user-session display ids are ignored; the
+    /// controller never authorizes those through this internal lane.
+    pub fn with_runtime_x11_authorizations(
+        mut self,
+        authorizations: Vec<RuntimeX11Authorization>,
+    ) -> Self {
+        self.runtime_x11_authorities = authorizations
+            .into_iter()
+            .filter(|authorization| authorization.display_id > 0)
+            .map(|authorization| (authorization.display_id, authorization.xauthority_path))
+            .collect();
+        self
+    }
+
+    /// Select the exact private authorization for `display_id` when the
+    /// controller supplied one, otherwise preserve the ordinary merged
+    /// session authorization behavior. A stale private path is deliberately
+    /// returned as-is so display teardown fails closed instead of silently
+    /// falling back to an ambient cookie.
+    fn xauthority_for_display(&self, display_id: i32) -> Option<&Path> {
+        self.runtime_x11_authorities
+            .get(&display_id)
+            .map(PathBuf::as_path)
+            .or(self.session_xauthority.as_deref())
     }
 
     fn resolve_log_dir() -> Result<PathBuf, AgentError> {
@@ -786,8 +821,8 @@ impl Agent {
         for name in shell_env_scrub_list(std::env::vars_os().map(|(k, _)| k)) {
             cmd_builder.env_remove(&name);
         }
-        if !self.synthetic_display_runtime {
-            if let Some(ref xauth) = self.session_xauthority {
+        if let Some(display_id) = display_id {
+            if let Some(xauth) = self.xauthority_for_display(display_id) {
                 cmd_builder.env("XAUTHORITY", xauth);
             }
         }
@@ -893,7 +928,7 @@ impl Agent {
                 &format!(":{}", display),
                 &screenshot_path.to_string_lossy(),
             ]);
-            if let Some(ref xauth) = self.session_xauthority {
+            if let Some(xauth) = self.xauthority_for_display(display) {
                 cmd_builder.env("XAUTHORITY", xauth);
             }
             cmd_builder.output().await?
@@ -2131,11 +2166,33 @@ mod tests {
             pty_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             available_displays: vec![],
             session_xauthority: None,
+            runtime_x11_authorities: HashMap::new(),
             synthetic_display_runtime: true,
             human_response_token: None,
             runtime_protocol_token: None,
         };
         (agent, log_dir)
+    }
+
+    #[test]
+    fn controller_xauthority_is_selected_per_display_and_precedes_ambient_merge() {
+        let (mut agent, _log_dir) = create_test_agent();
+        agent.session_xauthority = Some(PathBuf::from("/fixture/ambient.Xauthority"));
+        let agent = agent.with_runtime_x11_authorizations(vec![RuntimeX11Authorization {
+            display_id: 137,
+            xauthority_path: PathBuf::from("/fixture/private-137.Xauthority"),
+        }]);
+
+        assert_eq!(
+            agent.xauthority_for_display(137),
+            Some(Path::new("/fixture/private-137.Xauthority")),
+            "the exact controller-selected private credential must win"
+        );
+        assert_eq!(
+            agent.xauthority_for_display(99),
+            Some(Path::new("/fixture/ambient.Xauthority")),
+            "ordinary displays retain the existing merged-session behavior"
+        );
     }
 
     #[test]
@@ -2493,6 +2550,7 @@ mod tests {
     async fn process_input_exec_returns_result() {
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_x11_authorizations: vec![],
             runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {
@@ -2519,6 +2577,7 @@ mod tests {
     async fn process_input_unknown_function() {
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_x11_authorizations: vec![],
             runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {
@@ -2537,6 +2596,7 @@ mod tests {
         let dir = tmp.path().to_str().unwrap().to_string();
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_x11_authorizations: vec![],
             runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {
@@ -2564,6 +2624,7 @@ mod tests {
         let dir = tmp.path().to_str().unwrap().to_string();
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_x11_authorizations: vec![],
             runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![
@@ -2859,6 +2920,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let fp = tmp.path().join("integration.txt");
         let input = AgentInput {
+            runtime_x11_authorizations: vec![],
             runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -10,6 +10,7 @@ use tokio::time::{timeout, Duration};
 /// Maximum bytes to read from agent stdout/stderr (64 MB).
 const MAX_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
 const RUNTIME_PROTOCOL_TOKEN_FIELD: &str = "runtime_protocol_token";
+const RUNTIME_X11_AUTHORIZATIONS_FIELD: &str = "runtime_x11_authorizations";
 
 /// Per-batch askHuman answer tokens, keyed by the batch's log dir. The
 /// runtime only accepts a `human_response` file whose first line matches
@@ -129,6 +130,89 @@ fn arm_runtime_protocol_token(json_input: &str) -> (Option<String>, Option<Strin
         serde_json::Value::String(token.clone()),
     );
     (Some(parsed.to_string()), Some(token))
+}
+
+/// Replace any model-supplied private-display authorization list with paths
+/// selected from the controller's live Xvfb registry. Only GUI-capable
+/// commands' explicit positive display ids, plus the caller-owned default
+/// virtual display, are considered. The resulting list rides the runtime's
+/// one-shot stdin rather than ambient process state.
+fn arm_runtime_x11_authorizations(
+    json_input: &str,
+    virtual_display_id: Option<u32>,
+) -> Option<String> {
+    arm_runtime_x11_authorizations_with(json_input, virtual_display_id, |display_id| {
+        #[cfg(target_os = "linux")]
+        {
+            crate::vision::virtual_display_x11_authorization(display_id)
+                .map(|authorization| authorization.xauthority_path().to_path_buf())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = display_id;
+            None
+        }
+    })
+}
+
+fn arm_runtime_x11_authorizations_with<Resolve>(
+    json_input: &str,
+    virtual_display_id: Option<u32>,
+    mut resolve: Resolve,
+) -> Option<String>
+where
+    Resolve: FnMut(u32) -> Option<PathBuf>,
+{
+    let mut parsed: serde_json::Value = serde_json::from_str(json_input).ok()?;
+    let map = parsed.as_object_mut()?;
+    // Delete first so an empty/unsupported resolution can never preserve a
+    // forged model value.
+    map.remove(RUNTIME_X11_AUTHORIZATIONS_FIELD);
+
+    let mut display_ids = std::collections::BTreeSet::new();
+    if let Some(display_id) = virtual_display_id {
+        if display_id > 0 {
+            display_ids.insert(display_id);
+        }
+    }
+    if let Some(commands) = map.get("commands").and_then(serde_json::Value::as_array) {
+        for command in commands {
+            let Some(function) = command.get("function").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            if !matches!(function, "execAsAgent" | "execPty" | "captureScreen") {
+                continue;
+            }
+            let Some(display_id) = command.get("display").and_then(serde_json::Value::as_i64)
+            else {
+                continue;
+            };
+            if let Ok(display_id) = u32::try_from(display_id) {
+                if display_id > 0 {
+                    display_ids.insert(display_id);
+                }
+            }
+        }
+    }
+
+    let authorizations: Vec<serde_json::Value> = display_ids
+        .into_iter()
+        .filter_map(|display_id| {
+            resolve(display_id).map(|xauthority_path| {
+                serde_json::json!({
+                    "display_id": display_id,
+                    "xauthority_path": xauthority_path,
+                })
+            })
+        })
+        .collect();
+    if !authorizations.is_empty() {
+        map.insert(
+            RUNTIME_X11_AUTHORIZATIONS_FIELD.to_string(),
+            serde_json::to_value(authorizations).expect("runtime X11 authorizations serialize"),
+        );
+    }
+    Some(parsed.to_string())
 }
 
 /// Write an askHuman answer the runtime will accept: the batch token (when
@@ -818,6 +902,8 @@ async fn run_agent_inner(
     // environment.
     let (protocol_input, protocol_token) = arm_runtime_protocol_token(json_input);
     let protocol_input = protocol_input.as_deref().unwrap_or(json_input);
+    let x11_input = arm_runtime_x11_authorizations(protocol_input, virtual_display_id);
+    let protocol_input = x11_input.as_deref().unwrap_or(protocol_input);
     let (human_input, _human_token_guard) = if has_ask_human {
         arm_human_response_token(protocol_input, log_dir)
     } else {
@@ -1087,6 +1173,49 @@ mod tests {
 
         assert_eq!(arm_runtime_protocol_token("not json"), (None, None));
         assert_eq!(arm_runtime_protocol_token("[]"), (None, None));
+    }
+
+    #[test]
+    fn runtime_x11_authorizations_are_controller_selected_and_display_scoped() {
+        let forged = r#"{
+            "commands":[
+                {"function":"execAsAgent","nonce":1,"display":137},
+                {"function":"captureScreen","nonce":2,"display":138},
+                {"function":"execPty","nonce":3,"display":137},
+                {"function":"inspectPath","nonce":4,"display":139},
+                {"function":"execAsAgent","nonce":5,"display":-1}
+            ],
+            "runtime_x11_authorizations":[
+                {"display_id":1,"xauthority_path":"/model/forged"}
+            ]
+        }"#;
+        let mut resolved = Vec::new();
+        let armed = arm_runtime_x11_authorizations_with(forged, Some(140), |display_id| {
+            resolved.push(display_id);
+            match display_id {
+                137 => Some(PathBuf::from("/controller/private-137")),
+                140 => Some(PathBuf::from("/controller/private-140")),
+                _ => None,
+            }
+        })
+        .expect("valid batch JSON must re-serialize");
+        assert_eq!(resolved, vec![137, 138, 140]);
+
+        let parsed: serde_json::Value = serde_json::from_str(&armed).unwrap();
+        assert_eq!(
+            parsed[RUNTIME_X11_AUTHORIZATIONS_FIELD],
+            serde_json::json!([
+                {"display_id": 137, "xauthority_path": "/controller/private-137"},
+                {"display_id": 140, "xauthority_path": "/controller/private-140"},
+            ])
+        );
+        assert!(!armed.contains("/model/forged"));
+
+        let stripped = arm_runtime_x11_authorizations_with(forged, None, |_| None)
+            .expect("valid batch JSON must re-serialize");
+        let stripped: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+        assert!(stripped.get(RUNTIME_X11_AUTHORIZATIONS_FIELD).is_none());
+        assert!(arm_runtime_x11_authorizations_with("not json", None, |_| None).is_none());
     }
 
     #[test]

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -998,6 +998,13 @@ async fn launch_cdp_browser(
     let mut command = tokio::process::Command::new(&executable.path);
     #[cfg(target_os = "linux")]
     if let Some(binding) = display_binding.as_ref() {
+        let authorization = crate::vision::virtual_display_x11_authorization(binding.display_id)
+            .ok_or_else(|| {
+                BrowserWorkspaceError::Launch(format!(
+                    "browser workspace display {} has no live private X11 authorization",
+                    binding.canonical
+                ))
+            })?;
         // A bound workspace must use only its leased X11 display. Ambient
         // Wayland/Xauthority state belongs to the daemon's login session and
         // must not redirect or authorize this isolated browser child.
@@ -1005,7 +1012,7 @@ async fn launch_cdp_browser(
             .env("DISPLAY", format!(":{}", binding.display_id))
             .env("XDG_SESSION_TYPE", "x11")
             .env_remove("WAYLAND_DISPLAY")
-            .env_remove("XAUTHORITY")
+            .env("XAUTHORITY", authorization.xauthority_path())
             .arg("--ozone-platform=x11");
     }
     command

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -1059,11 +1059,13 @@ pub async fn execute_actions(
     let session_only = matches!(
         effective_backend,
         DisplayBackend::Wayland | DisplayBackend::Windows
-    );
+    ) || target_uses_private_x11_session(target);
 
     if session_only {
         // Session-only backends: capture and input both live in the display
-        // pipeline (Wayland portal / Windows DXGI + SendInput).
+        // pipeline (Wayland portal, Windows DXGI + SendInput, or an
+        // authenticated private X11 connection). Private X11 must never fall
+        // back to ambient xauth discovery or unauthenticated subprocesses.
         let Some(live) = lookup_display_session(session_registry, &target).await else {
             return CuBatchOutcome {
                 results: vec![CuActionResult::failed(no_session_message(
@@ -1176,6 +1178,19 @@ pub async fn execute_actions(
         outcome.metrics_line(),
     );
     outcome
+}
+
+fn target_uses_private_x11_session(target: DisplayTarget) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        matches!(target, DisplayTarget::Virtual { id } if
+            crate::vision::virtual_display_x11_authorization(id).is_some())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = target;
+        false
+    }
 }
 
 /// The X11/macOS action loop: subprocess/CGEvent input injection, session

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -727,7 +727,15 @@ async fn activate_user_display_inner(
     #[cfg(target_os = "linux")]
     if target_display_id != 0 && vision::virtual_display_socket_exists(target_display_id) {
         let display_str = format!(":{target_display_id}");
-        let backend = match display::x11::X11Backend::with_display(&display_str) {
+        let backend = match vision::virtual_display_x11_authorization(target_display_id) {
+            Some(authorization) => display::x11::X11Backend::with_display_authorization(
+                &display_str,
+                authorization.protocol(),
+                authorization.cookie(),
+            ),
+            None => display::x11::X11Backend::with_display(&display_str),
+        };
+        let backend = match backend {
             Ok(backend) => backend,
             Err(e) => {
                 report_user_display_capture_unavailable_with_generation(

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -56,10 +56,19 @@ fn browser_bindable_displays() -> &'static Mutex<HashSet<u32>> {
 /// create/reap lifecycle that also retires browser workspaces. Generic
 /// session-local Xvfb guards are intentionally excluded.
 pub(crate) fn process_owns_browser_bindable_display(display_id: u32) -> bool {
-    browser_bindable_displays()
+    let lifecycle_owned = browser_bindable_displays()
         .lock()
         .is_ok_and(|displays| displays.contains(&display_id))
-        && vision::process_owns_virtual_display(display_id)
+        && vision::process_owns_virtual_display(display_id);
+    #[cfg(target_os = "linux")]
+    {
+        lifecycle_owned && vision::virtual_display_x11_authorization(display_id).is_some()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = lifecycle_owned;
+        false
+    }
 }
 
 fn register_browser_bindable_display(display_id: u32) {
@@ -102,7 +111,6 @@ impl VirtualDisplayGuards {
     ) {
         self.processes.insert(display_id, guard);
         self.ownership.insert(display_id, ownership);
-        register_browser_bindable_display(display_id);
     }
 
     fn remove(&mut self, display_id: &u32) -> Option<vision::XvfbGuard> {
@@ -227,7 +235,7 @@ pub(crate) async fn create_virtual_display(
         return;
     };
 
-    match vision::launch_display(&config).await {
+    match vision::launch_private_display(&config).await {
         Ok(guard) => {
             let capture_generation = format!("vdcg-{}", uuid::Uuid::new_v4().simple());
             guards.insert(
@@ -332,6 +340,11 @@ pub(crate) async fn handle_virtual_display_capture_readiness(
         .await;
         return;
     }
+
+    // A browser may bind only after capture has stayed live through the
+    // readiness window. Before this point the X server exists but is not a
+    // usable, evidence-producing workspace.
+    register_browser_bindable_display(display_id);
 
     let request_id = ownership.request_id.clone();
     let width = ownership.width;

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ async fn main() -> Result<(), AgentError> {
 
     // Create agent instance
     let agent = Agent::new()?
+        .with_runtime_x11_authorizations(input.runtime_x11_authorizations.clone())
         .with_human_response_token(input.human_response_token.clone())
         .with_runtime_protocol_token(input.runtime_protocol_token.clone());
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -28,6 +28,14 @@ pub struct Command {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentInput {
     pub commands: Vec<Command>,
+    /// Controller-selected Xauthority files for daemon-owned private X11
+    /// displays referenced by this batch. The controller removes any
+    /// model-supplied value and rebuilds this list from live display state
+    /// immediately before spawning the runtime. Paths travel only over the
+    /// runtime's one-shot stdin; each GUI command receives only the entry for
+    /// its selected display.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_x11_authorizations: Vec<RuntimeX11Authorization>,
     /// Controller-minted per-spawn secret authenticating runtime JSONL
     /// results. The controller overwrites any model-supplied value before
     /// spawn, and strips it again after verification. It is delivered only
@@ -44,6 +52,12 @@ pub struct AgentInput {
     /// answers accepted unauthenticated.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub human_response_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeX11Authorization {
+    pub display_id: i32,
+    pub xauthority_path: std::path::PathBuf,
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary

- launch dashboard-owned Xvfb displays with a fresh per-display MIT-MAGIC-COOKIE-1 and `-nolisten tcp`
- carry private authorization only in daemon memory/process-owned storage and authenticate capture, input, XDamage, bound Chromium, and runtime GUI commands explicitly
- discard forged runtime authorization records and select the exact controller-authenticated Xauthority for each requested display
- prevent private displays from falling back to ambient X11 credentials or subprocess input paths
- keep unit tests hermetic; provide `private-xvfb-auth-smoke` as the explicit manual live acceptance example

## Validation

- `cargo test --bin intendant browser_workspace`
- `cargo test -p intendant-display x11_input`
- `cargo test -p intendant-platform vision`
- `cargo test --bin intendant runtime_x11_authorizations_are_controller_selected_and_display_scoped`
- `cargo test --bin intendant-runtime controller_xauthority_is_selected_per_display_and_precedes_ambient_merge`
- `cargo check -p intendant-platform --examples`
- `cargo clippy --bin intendant --all-features -- -D warnings`
- `cargo clippy -p intendant-display -p intendant-platform -- -D warnings`
- disposable Debian host: full Linux caller check and live private-Xvfb acceptance passed; checkout/toolchain removed afterward

No Xauthority path or cookie is serialized into workspace records or portable evidence.