### PR TITLE
Display: add generation-bound virtual teardown

### DIFF
--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -419,7 +419,12 @@ impl XvfbGuard {
     /// runtime worker. Graceful waiting is bounded; the fallback hard-kills
     /// only the spawned child. X lock/socket residue is never removed because
     /// its ownership is ambiguous once the child has exited.
-    pub async fn shutdown(mut self) {
+    ///
+    /// Returns `true` only when the child exit was observed and, on Linux, its
+    /// exact X lock and socket are both absent. Receipt-bearing callers must
+    /// check this result instead of turning a diagnostic-only shutdown failure
+    /// into a successful teardown claim.
+    pub async fn shutdown(mut self) -> bool {
         #[cfg(target_os = "linux")]
         {
             // New browser launches must stop treating this display as owned
@@ -428,13 +433,14 @@ impl XvfbGuard {
             match self.child.try_wait() {
                 Ok(Some(_)) => {
                     self.report_residual_state();
-                    return;
+                    return owned_xvfb_paths_are_cleared(
+                        std::path::Path::new("/tmp"),
+                        self.display_id,
+                    );
                 }
                 Ok(None) => {}
                 Err(err) => {
                     eprintln!("[vision] failed to inspect Xvfb child before shutdown: {err}");
-                    let _ = self.child.kill().await;
-                    return;
                 }
             }
 
@@ -444,7 +450,10 @@ impl XvfbGuard {
                 {
                     Ok(Ok(_)) => {
                         self.report_residual_state();
-                        return;
+                        return owned_xvfb_paths_are_cleared(
+                            std::path::Path::new("/tmp"),
+                            self.display_id,
+                        );
                     }
                     Ok(Err(err)) => {
                         eprintln!("[vision] failed to reap Xvfb child after SIGTERM: {err}");
@@ -457,7 +466,22 @@ impl XvfbGuard {
         // `Child::kill` targets this guard's exact spawned child and awaits
         // its exit. Drop remains the nonblocking fallback if this future is
         // cancelled before the await completes.
-        let _ = self.child.kill().await;
+        let killed = match self.child.kill().await {
+            Ok(()) => true,
+            Err(err) => {
+                eprintln!("[vision] failed to kill and reap Xvfb child: {err}");
+                false
+            }
+        };
+        #[cfg(target_os = "linux")]
+        {
+            self.report_residual_state();
+            killed && owned_xvfb_paths_are_cleared(std::path::Path::new("/tmp"), self.display_id)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            killed
+        }
     }
 
     #[cfg(target_os = "linux")]

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -214,11 +214,15 @@ CU actions operate on a `DisplayTarget` (`#[serde(tag = "kind")]`):
   **New virtual display** action and a first-class MCP tool
   (`intendant ctl display create [--width N] [--height N]`, federated via
   `ctl --peer`; it awaits the ready/failed outcome and returns the new
-  display's id) — the path that gives an authorized headless box a
-  display with no API key configured. Created displays register a
-  capture session immediately (streaming tile, CU-routable, announced to
-  dashboards and federated peers), are daemon-owned,
-  and are destroyed when their tile is closed (a hard daemon kill leaves the
+  display's id plus an opaque capture generation) — the path that gives an
+  authorized headless box a display with no API key configured. Created
+  displays register a capture session immediately (streaming tile,
+  CU-routable, announced to dashboards and federated peers) and are
+  daemon-owned. Automated callers tear
+  down exactly the generation they created with
+  `intendant ctl display destroy DISPLAY_ID CAPTURE_GENERATION`; stale
+  generations are refused and bound browsers are retired first. Displays are
+  also destroyed when their tile is closed (a hard daemon kill leaves the
   usual orphan for the next allocation to reclaim). Xvfb is Linux-only; other
   platforms answer the action with a clear error.
 - **`UserSession`** — the user's real desktop. On Linux X11 it resolves the

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -60,7 +60,7 @@ agent-to-user collaboration primitives (`post_session_note`, `ask_user`,
 `notify_user`); the Agenda tools (`agenda_list`, `agenda_item`, `agenda_op`)
 and the Memory retrieval/propose tools; the shared-view
 tools; and the minimal display/CU set (`list_displays`,
-`create_virtual_display`, `grant_user_display`, `request_user_display`,
+`create_virtual_display`, `destroy_virtual_display`, `grant_user_display`, `request_user_display`,
 `revoke_user_display`, `take_screenshot`, `read_screen`, `execute_cu_actions`,
 `display_readiness`) — managed and vanilla alike. Managed context additionally
 advertises rewind/backout and fission tools. The other profile names
@@ -347,7 +347,8 @@ claim instead.
 | Tool                 | Description | Params |
 |----------------------|-------------|--------|
 | `list_displays`      | Enumerate displays with their session state. | — |
-| `create_virtual_display` | Create a daemon-owned virtual display (Xvfb) and activate it for capture and streaming; it announces as `display_ready` to every dashboard and federated peer. On Linux, each dashboard-created display has a fresh daemon-held Xauthority cookie and no X11 TCP listener; capture, input, and its bound browser authenticate explicitly. The display survives the calling session and dies with the daemon; closing its dashboard tile (or revoking its id) reaps it early. Linux hosts only today — other platforms report a clear error. | `width?`, `height?` |
+| `create_virtual_display` | Create a daemon-owned virtual display (Xvfb) and activate it for capture and streaming; it announces as `display_ready` to every dashboard and federated peer and returns its id plus an opaque `capture_generation`. On Linux, each dashboard-created display has a fresh daemon-held Xauthority cookie and no X11 TCP listener; capture, input, and its bound browser authenticate explicitly. The display survives the calling session and dies with the daemon; closing its dashboard tile (or revoking its id) reaps it early. Linux hosts only today — other platforms report a clear error. | `width?`, `height?` |
+| `destroy_virtual_display` | Destroy exactly the daemon-owned virtual-display generation returned by `create_virtual_display`. Bound browser workspaces are retired before capture and Xvfb; a stale generation is refused without touching the live display. | `display_id`, `capture_generation`, `note?` |
 | `take_display`       | Optional dashboard signal that an agent is using a display; it neither grants input authority nor is required before screenshot/CU calls. | `display_id` |
 | `release_display`    | Release control of a display. | `display_id`, `note?` |
 | `grant_user_display` | Grant access to the user's real display session (owner surfaces only — this call *is* the opt-in); on Wayland, enable **Allow Remote Interaction** in the GNOME portal before clicking **Share** so CU input works. | `display_id?` |

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -1096,6 +1096,7 @@ pub fn control_msg_operation(ctrl: &ControlMsg) -> PeerOperation {
         | ControlMsg::RevokeUserDisplay { .. }
         | ControlMsg::ResolveDisplayRequest { .. }
         | ControlMsg::CreateVirtualDisplay { .. }
+        | ControlMsg::DestroyVirtualDisplay { .. }
         | ControlMsg::SetDiagnosticsVisualMarker { .. } => PeerOperation::DisplayInput,
         ControlMsg::Input { .. }
         | ControlMsg::FollowUp { .. }

--- a/src/bin/caller/access/hosted_control/policy.rs
+++ b/src/bin/caller/access/hosted_control/policy.rs
@@ -649,6 +649,7 @@ pub fn hosted_control_msg_allowed(
         | ControlMsg::RevokeUserDisplay { .. }
         | ControlMsg::ResolveDisplayRequest { .. }
         | ControlMsg::CreateVirtualDisplay { .. }
+        | ControlMsg::DestroyVirtualDisplay { .. }
         | ControlMsg::SetDiagnosticsVisualMarker { .. }
         | ControlMsg::PeerFileTransferSignal { .. }
         | ControlMsg::PeerDashboardControlSignal { .. }

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -995,6 +995,37 @@ async fn run_display(
                 call_tool(client, config, "create_virtual_display", Value::Object(map)).await?;
             print_tool_response(response, config, None)?;
         }
+        "destroy" => {
+            let args = parse_command_args(&raw[1..], &["--note"], &[])?;
+            let display_id = positional_u32(
+                &args,
+                0,
+                "display destroy requires DISPLAY_ID and CAPTURE_GENERATION",
+            )?;
+            let capture_generation = args.positional.get(1).ok_or_else(|| {
+                "display destroy requires DISPLAY_ID and CAPTURE_GENERATION".to_string()
+            })?;
+            if args.positional.len() > 2 {
+                return Err(
+                    "display destroy accepts exactly DISPLAY_ID and CAPTURE_GENERATION".to_string(),
+                );
+            }
+            let mut map = Map::new();
+            map.insert("display_id".to_string(), Value::from(display_id));
+            map.insert(
+                "capture_generation".to_string(),
+                Value::String(capture_generation.clone()),
+            );
+            insert_string(&mut map, "note", args.one("--note"));
+            let response = call_tool(
+                client,
+                config,
+                "destroy_virtual_display",
+                Value::Object(map),
+            )
+            .await?;
+            print_tool_response(response, config, None)?;
+        }
         "frames" => {
             let args = parse_command_args(&raw[1..], &["--stream", "--count"], &[])?;
             let mut map = Map::new();
@@ -5987,6 +6018,7 @@ fn help_display() {
         "Usage:\n\
   intendant ctl display list\n\
   intendant ctl display create [--width N] [--height N]\n\
+  intendant ctl display destroy DISPLAY_ID CAPTURE_GENERATION [--note TEXT]\n\
   intendant ctl display status [--target TARGET]\n\
   intendant ctl display frames [--stream NAME] [--count N]\n\
   intendant ctl display read-frame [latest|ID] [--stream NAME]\n\

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1802,6 +1802,7 @@ pub(crate) const DASHBOARD_ACTION_MSG_ACTIONS: &[&str] = &[
     "revoke_user_display",
     "resolve_display_request",
     "create_virtual_display",
+    "destroy_virtual_display",
     "create_browser_workspace",
     "close_browser_workspace",
     "acquire_browser_workspace",
@@ -1888,6 +1889,7 @@ pub(crate) fn dashboard_control_msg_action(ctrl: &ControlMsg) -> &'static str {
         ControlMsg::RevokeUserDisplay { .. } => "revoke_user_display",
         ControlMsg::ResolveDisplayRequest { .. } => "resolve_display_request",
         ControlMsg::CreateVirtualDisplay { .. } => "create_virtual_display",
+        ControlMsg::DestroyVirtualDisplay { .. } => "destroy_virtual_display",
         ControlMsg::CreateBrowserWorkspace { .. } => "create_browser_workspace",
         ControlMsg::CloseBrowserWorkspace { .. } => "close_browser_workspace",
         ControlMsg::AcquireBrowserWorkspace { .. } => "acquire_browser_workspace",
@@ -4328,6 +4330,14 @@ mod tests {
             "create_virtual_display",
             || serde_json::json!({"action": "create_virtual_display", "width": 1280, "height": 800}),
         ),
+        ("destroy_virtual_display", || {
+            serde_json::json!({
+                "action": "destroy_virtual_display",
+                "request_id": "vdd-test",
+                "display_id": 99,
+                "capture_generation": "vdcg-test"
+            })
+        }),
         (
             "close_browser_workspace",
             || serde_json::json!({"action": "close_browser_workspace", "workspace_id": "w"}),

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1802,7 +1802,6 @@ pub(crate) const DASHBOARD_ACTION_MSG_ACTIONS: &[&str] = &[
     "revoke_user_display",
     "resolve_display_request",
     "create_virtual_display",
-    "destroy_virtual_display",
     "create_browser_workspace",
     "close_browser_workspace",
     "acquire_browser_workspace",
@@ -4330,14 +4329,6 @@ mod tests {
             "create_virtual_display",
             || serde_json::json!({"action": "create_virtual_display", "width": 1280, "height": 800}),
         ),
-        ("destroy_virtual_display", || {
-            serde_json::json!({
-                "action": "destroy_virtual_display",
-                "request_id": "vdd-test",
-                "display_id": 99,
-                "capture_generation": "vdcg-test"
-            })
-        }),
         (
             "close_browser_workspace",
             || serde_json::json!({"action": "close_browser_workspace", "workspace_id": "w"}),

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -252,8 +252,25 @@ pub enum VirtualDisplayCreateOutcome {
         display_id: u32,
         width: u32,
         height: u32,
+        capture_generation: String,
     },
     Failed {
+        reason: String,
+    },
+}
+
+/// Request-scoped terminal result for destroying one exact daemon-owned
+/// virtual-display generation. A refused result is deliberately distinct
+/// from a successful no-op: callers must not treat an absent or stale
+/// generation as proof that the display they created was torn down.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VirtualDisplayDestroyOutcome {
+    Destroyed {
+        display_id: u32,
+        capture_generation: String,
+        closed_browser_workspace_ids: Vec<String>,
+    },
+    Refused {
         reason: String,
     },
 }
@@ -264,8 +281,16 @@ pub enum VirtualDisplayCreateWaitError {
     Closed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtualDisplayDestroyWaitError {
+    TimedOut,
+    Closed,
+}
+
 type VirtualDisplayCreateWaiters =
     Arc<Mutex<HashMap<String, tokio::sync::oneshot::Sender<VirtualDisplayCreateOutcome>>>>;
+type VirtualDisplayDestroyWaiters =
+    Arc<Mutex<HashMap<String, tokio::sync::oneshot::Sender<VirtualDisplayDestroyOutcome>>>>;
 
 /// RAII owner for one request-scoped terminal result. Dropping a cancelled or
 /// timed-out call removes its sender so abandoned MCP calls cannot accumulate
@@ -290,6 +315,36 @@ impl VirtualDisplayCreateWaiter {
 }
 
 impl Drop for VirtualDisplayCreateWaiter {
+    fn drop(&mut self) {
+        if let Ok(mut waiters) = self.waiters.lock() {
+            waiters.remove(&self.request_id);
+        }
+    }
+}
+
+/// RAII owner for one generation-bound destroy result. Cancellation removes
+/// the sender, and the serial display owner checks that liveness before it
+/// performs any destructive work.
+pub struct VirtualDisplayDestroyWaiter {
+    request_id: String,
+    waiters: VirtualDisplayDestroyWaiters,
+    receiver: tokio::sync::oneshot::Receiver<VirtualDisplayDestroyOutcome>,
+}
+
+impl VirtualDisplayDestroyWaiter {
+    pub async fn wait(
+        mut self,
+        timeout_after: Duration,
+    ) -> Result<VirtualDisplayDestroyOutcome, VirtualDisplayDestroyWaitError> {
+        match tokio::time::timeout(timeout_after, &mut self.receiver).await {
+            Ok(Ok(outcome)) => Ok(outcome),
+            Ok(Err(_closed)) => Err(VirtualDisplayDestroyWaitError::Closed),
+            Err(_elapsed) => Err(VirtualDisplayDestroyWaitError::TimedOut),
+        }
+    }
+}
+
+impl Drop for VirtualDisplayDestroyWaiter {
     fn drop(&mut self) {
         if let Ok(mut waiters) = self.waiters.lock() {
             waiters.remove(&self.request_id);
@@ -2699,6 +2754,18 @@ pub enum ControlMsg {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         height: Option<u32>,
     },
+    /// Destroy one exact daemon-owned virtual-display generation. Numeric
+    /// X11 display ids can be reused, so both the id and the opaque
+    /// generation returned by `create_virtual_display` are mandatory. The
+    /// request id belongs to an in-process waiter; unregistered/cancelled
+    /// requests are ignored before any teardown begins.
+    DestroyVirtualDisplay {
+        request_id: String,
+        display_id: u32,
+        capture_generation: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+    },
     /// **Phase 0 visual-freshness diagnostic** (task #83). Toggle the
     /// per-display marker overlay that the pool-feed bridge stamps into
     /// the I420 Y plane. Off by default; operator flips it on for a
@@ -2981,6 +3048,7 @@ pub struct EventBus {
     session_log_sinks: Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<SessionLogLaneItem>>>>,
     intent_sinks: Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<AppEvent>>>>,
     virtual_display_create_waiters: VirtualDisplayCreateWaiters,
+    virtual_display_destroy_waiters: VirtualDisplayDestroyWaiters,
 }
 
 impl EventBus {
@@ -2991,6 +3059,7 @@ impl EventBus {
             session_log_sinks: Arc::new(Mutex::new(Vec::new())),
             intent_sinks: Arc::new(Mutex::new(Vec::new())),
             virtual_display_create_waiters: Arc::new(Mutex::new(HashMap::new())),
+            virtual_display_destroy_waiters: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -3038,6 +3107,50 @@ impl EventBus {
     /// unowned display when cancellation state is ambiguous.
     pub fn virtual_display_create_is_pending(&self, request_id: &str) -> bool {
         self.virtual_display_create_waiters
+            .lock()
+            .is_ok_and(|waiters| waiters.contains_key(request_id))
+    }
+
+    /// Register a generation-bound destroy result before publishing its
+    /// intent. Occupied ids are refused instead of replacing another caller.
+    pub fn register_virtual_display_destroy_waiter(
+        &self,
+        request_id: String,
+    ) -> Result<VirtualDisplayDestroyWaiter, String> {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let mut waiters = self
+            .virtual_display_destroy_waiters
+            .lock()
+            .map_err(|_| "virtual display destroy result registry is unavailable".to_string())?;
+        if waiters.contains_key(&request_id) {
+            return Err("virtual display destroy request id is already pending".to_string());
+        }
+        waiters.insert(request_id.clone(), sender);
+        drop(waiters);
+        Ok(VirtualDisplayDestroyWaiter {
+            request_id,
+            waiters: Arc::clone(&self.virtual_display_destroy_waiters),
+            receiver,
+        })
+    }
+
+    pub fn complete_virtual_display_destroy(
+        &self,
+        request_id: &str,
+        outcome: VirtualDisplayDestroyOutcome,
+    ) -> bool {
+        let sender = self
+            .virtual_display_destroy_waiters
+            .lock()
+            .ok()
+            .and_then(|mut waiters| waiters.remove(request_id));
+        sender.is_some_and(|sender| sender.send(outcome).is_ok())
+    }
+
+    /// Whether the exact destroy caller is still waiting. Poisoning fails
+    /// closed, as does cancellation: neither may initiate teardown.
+    pub fn virtual_display_destroy_is_pending(&self, request_id: &str) -> bool {
+        self.virtual_display_destroy_waiters
             .lock()
             .is_ok_and(|waiters| waiters.contains_key(request_id))
     }
@@ -6872,6 +6985,27 @@ mod tests {
         ));
         let serialized = serde_json::to_value(&msg).unwrap();
         assert_eq!(serialized["request_id"], "vdc-abc");
+    }
+
+    #[test]
+    fn control_msg_destroy_virtual_display_requires_exact_generation() {
+        let json = r#"{"action":"destroy_virtual_display","request_id":"vdd-abc","display_id":99,"capture_generation":"vdcg-abc","note":"capture complete"}"#;
+        let msg: ControlMsg = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            msg,
+            ControlMsg::DestroyVirtualDisplay {
+                ref request_id,
+                display_id: 99,
+                ref capture_generation,
+                note: Some(ref note),
+            } if request_id == "vdd-abc"
+                && capture_generation == "vdcg-abc"
+                && note == "capture complete"
+        ));
+
+        let missing_generation =
+            r#"{"action":"destroy_virtual_display","request_id":"vdd-abc","display_id":99}"#;
+        assert!(serde_json::from_str::<ControlMsg>(missing_generation).is_err());
     }
 
     #[test]

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3382,6 +3382,23 @@ pub fn spawn_user_display_listener(
                     )
                     .await;
                 }
+                AppEvent::ControlCommand(ControlMsg::DestroyVirtualDisplay {
+                    request_id,
+                    display_id,
+                    capture_generation,
+                    note,
+                }) => {
+                    virtual_display::destroy_virtual_display(
+                        &bus,
+                        &session_registry,
+                        &mut virtual_display_guards,
+                        &request_id,
+                        display_id,
+                        &capture_generation,
+                        note.as_deref(),
+                    )
+                    .await;
+                }
                 AppEvent::UserDisplayRevoked { display_id, .. } => {
                     virtual_display::fail_pending_virtual_display_create(
                         &bus,

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1488,6 +1488,20 @@ pub(crate) async fn handle_control_command_mcp(
             );
             Some(RESOURCE_LOGS_URI)
         }
+        ControlMsg::DestroyVirtualDisplay { .. } => {
+            // The serial user-display listener owns generation validation,
+            // browser retirement, capture removal, and Xvfb shutdown. This
+            // surface acknowledges only that the correlated intent arrived.
+            emit_control_result(
+                control_tx,
+                "destroy_virtual_display",
+                true,
+                "generation-bound virtual display destruction requested; the correlated tool result reports success or refusal"
+                    .to_string(),
+                None,
+            );
+            Some(RESOURCE_LOGS_URI)
+        }
         ControlMsg::ListDisplays => {
             let session_registry = state.read().await.session_registry.clone();
             let displays =

--- a/src/bin/caller/mcp/facade/registry.rs
+++ b/src/bin/caller/mcp/facade/registry.rs
@@ -856,6 +856,18 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
         help: "Create a virtual display",
     },
     CommandSpec {
+        path: &["display", "destroy"],
+        lane: RiskLane::Act,
+        tool: "destroy_virtual_display",
+        seed: "{}",
+        positionals: &[
+            p_u64("DISPLAY_ID", "display_id"),
+            p_str("CAPTURE_GENERATION", "capture_generation", false, false),
+        ],
+        flags: &[flag!("note", "note", Str, "why the display is destroyed")],
+        help: "Destroy the exact generation returned by display create",
+    },
+    CommandSpec {
         path: &["display", "frames"],
         lane: RiskLane::Inspect,
         tool: "list_frames",

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1043,6 +1043,12 @@ impl IntendantServer {
                     self.create_virtual_display(Parameters(params)).await,
                 ))
             }
+            "destroy_virtual_display" => {
+                let Parameters(params) = parse_params::<DestroyVirtualDisplayParams>(args)?;
+                Ok(text_tool_result(
+                    self.destroy_virtual_display(Parameters(params)).await,
+                ))
+            }
             "take_display" => {
                 let params = parse_params::<TakeDisplayParams>(args)?;
                 Ok(text_tool_result(self.take_display(params).await))

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -203,6 +203,7 @@ pub(crate) fn tool_allowed_for_profile(
                     // control surface stays behind `intendant ctl`.
                     | "list_displays"
                     | "create_virtual_display"
+                    | "destroy_virtual_display"
                     | "grant_user_display"
                     // The doorbell for the user's own display — exists
                     // precisely for these scoped supervised callers.
@@ -245,6 +246,7 @@ pub(crate) fn tool_allowed_for_profile(
                     | "acquire_browser_workspace"
                     | "release_browser_workspace"
                     | "create_virtual_display"
+                    | "destroy_virtual_display"
                     | "grant_user_display"
                     | "request_user_display"
                     | "revoke_user_display"
@@ -447,6 +449,7 @@ pub(crate) fn mcp_tool_operation(name: &str) -> crate::peer::access_policy::Peer
         "take_display"
         | "release_display"
         | "create_virtual_display"
+        | "destroy_virtual_display"
         | "grant_user_display"
         | "revoke_user_display"
         | "request_shared_view_input"
@@ -881,8 +884,16 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
         "create_virtual_display",
         manual_http_tool_definition!(
             "create_virtual_display",
-            "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer, survives the calling session, and dies with the daemon (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry.",
+            "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer, survives the calling session, and dies with the daemon (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id, geometry, and opaque capture_generation required for exact teardown.",
             CreateVirtualDisplayParams
+        ),
+    );
+    push(
+        "destroy_virtual_display",
+        manual_http_tool_definition!(
+            "destroy_virtual_display",
+            "Destroy one exact daemon-owned virtual-display generation. Requires the display_id and capture_generation returned by create_virtual_display, closes bound browser workspaces first, and refuses stale generations without touching the live display.",
+            DestroyVirtualDisplayParams
         ),
     );
     push(

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -632,6 +632,18 @@ pub struct CreateVirtualDisplayParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DestroyVirtualDisplayParams {
+    /// Numeric display id returned by `create_virtual_display`.
+    pub display_id: u32,
+    /// Opaque generation returned by the same create call. Both values are
+    /// required so a stale cleanup cannot destroy a replacement display.
+    pub capture_generation: String,
+    /// Optional short lifecycle note included in retirement events.
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct RevokeUserDisplayParams {
     /// User session display ID to revoke. Omit for the primary display (0).
     #[serde(default)]

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -126,7 +126,7 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer and survives the calling session (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for this exact request's correlated terminal result and returns JSON with request_id plus the new display id/geometry or error."
+        description = "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer and survives the calling session (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for this exact request's correlated terminal result and returns JSON with request_id, display id/geometry, and the opaque capture_generation required for exact teardown."
     )]
     pub(crate) async fn create_virtual_display(
         &self,
@@ -161,13 +161,15 @@ impl IntendantServer {
                 display_id,
                 width,
                 height,
+                capture_generation,
             }) => serde_json::json!({
                 "ok": true,
                 "request_id": request_id,
                 "display_id": display_id,
                 "display_target": format!("display_{display_id}"),
                 "width": width,
-                "height": height
+                "height": height,
+                "capture_generation": capture_generation
             })
             .to_string(),
             Ok(crate::event::VirtualDisplayCreateOutcome::Failed { reason }) => serde_json::json!({
@@ -186,6 +188,81 @@ impl IntendantServer {
                 "ok": false,
                 "request_id": request_id,
                 "error": "virtual display event bus closed before the correlated result arrived"
+            })
+            .to_string(),
+        }
+    }
+
+    #[tool(
+        description = "Destroy one exact daemon-owned virtual-display generation. Requires the display_id and capture_generation returned by create_virtual_display, closes every browser bound to that display first, and waits for correlated teardown. A stale generation is refused without touching the live display."
+    )]
+    pub(crate) async fn destroy_virtual_display(
+        &self,
+        Parameters(params): Parameters<DestroyVirtualDisplayParams>,
+    ) -> String {
+        let request_id = format!("vdd-{}", uuid::Uuid::new_v4().simple());
+        let waiter = match self
+            .bus
+            .register_virtual_display_destroy_waiter(request_id.clone())
+        {
+            Ok(waiter) => waiter,
+            Err(error) => {
+                return serde_json::json!({
+                    "ok": false,
+                    "request_id": request_id,
+                    "display_id": params.display_id,
+                    "capture_generation": params.capture_generation,
+                    "error": error
+                })
+                .to_string();
+            }
+        };
+        self.bus.send(AppEvent::ControlCommand(
+            ControlMsg::DestroyVirtualDisplay {
+                request_id: request_id.clone(),
+                display_id: params.display_id,
+                capture_generation: params.capture_generation.clone(),
+                note: params.note,
+            },
+        ));
+        match waiter.wait(std::time::Duration::from_secs(20)).await {
+            Ok(crate::event::VirtualDisplayDestroyOutcome::Destroyed {
+                display_id,
+                capture_generation,
+                closed_browser_workspace_ids,
+            }) => serde_json::json!({
+                "ok": true,
+                "request_id": request_id,
+                "display_id": display_id,
+                "display_target": format!("display_{display_id}"),
+                "capture_generation": capture_generation,
+                "closed_browser_workspace_ids": closed_browser_workspace_ids
+            })
+            .to_string(),
+            Ok(crate::event::VirtualDisplayDestroyOutcome::Refused { reason }) => {
+                serde_json::json!({
+                    "ok": false,
+                    "request_id": request_id,
+                    "display_id": params.display_id,
+                    "capture_generation": params.capture_generation,
+                    "error": reason
+                })
+                .to_string()
+            }
+            Err(crate::event::VirtualDisplayDestroyWaitError::TimedOut) => serde_json::json!({
+                "ok": false,
+                "request_id": request_id,
+                "display_id": params.display_id,
+                "capture_generation": params.capture_generation,
+                "error": "virtual display destruction did not return its correlated result within 20s"
+            })
+            .to_string(),
+            Err(crate::event::VirtualDisplayDestroyWaitError::Closed) => serde_json::json!({
+                "ok": false,
+                "request_id": request_id,
+                "display_id": params.display_id,
+                "capture_generation": params.capture_generation,
+                "error": "virtual display event bus closed before the correlated destroy result arrived"
             })
             .to_string(),
         }
@@ -1822,6 +1899,7 @@ mod tests {
                 display_id: 89,
                 width: 640,
                 height: 480,
+                capture_generation: "generation-unrelated".to_string(),
             },
         ));
         // Overflow the best-effort broadcast ring. Terminal delivery uses a
@@ -1842,6 +1920,7 @@ mod tests {
                 display_id: 102,
                 width: 1000,
                 height: 700,
+                capture_generation: "generation-second".to_string(),
             },
         ));
         let second_json: serde_json::Value = serde_json::from_str(
@@ -1855,6 +1934,7 @@ mod tests {
         assert_eq!(second_json["request_id"], second_id);
         assert_eq!(second_json["display_id"], 102);
         assert_eq!(second_json["display_target"], "display_102");
+        assert_eq!(second_json["capture_generation"], "generation-second");
         assert!(!first.is_finished());
 
         assert!(bus.complete_virtual_display_create(
@@ -1906,6 +1986,80 @@ mod tests {
         assert!(!bus.complete_virtual_display_create(
             "vdc-cancelled",
             crate::event::VirtualDisplayCreateOutcome::Failed {
+                reason: "cancelled".to_string(),
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn exact_virtual_display_destroy_returns_its_correlated_receipt() {
+        let bus = EventBus::new();
+        let mut command_rx = bus.subscribe();
+        let server = IntendantServer::new(test_state(), bus.clone());
+        let destroy = tokio::spawn(async move {
+            server
+                .destroy_virtual_display(Parameters(DestroyVirtualDisplayParams {
+                    display_id: 99,
+                    capture_generation: "vdcg-live".to_string(),
+                    note: Some("capture complete".to_string()),
+                }))
+                .await
+        });
+
+        let request_id = loop {
+            match timeout(Duration::from_secs(1), command_rx.recv()).await {
+                Ok(Ok(AppEvent::ControlCommand(ControlMsg::DestroyVirtualDisplay {
+                    request_id,
+                    display_id: 99,
+                    capture_generation,
+                    note,
+                }))) => {
+                    assert_eq!(capture_generation, "vdcg-live");
+                    assert_eq!(note.as_deref(), Some("capture complete"));
+                    break request_id;
+                }
+                Ok(Ok(_)) => continue,
+                other => panic!("expected correlated destroy command, got {other:?}"),
+            }
+        };
+        assert!(bus.complete_virtual_display_destroy(
+            &request_id,
+            crate::event::VirtualDisplayDestroyOutcome::Destroyed {
+                display_id: 99,
+                capture_generation: "vdcg-live".to_string(),
+                closed_browser_workspace_ids: vec!["bw-1".to_string()],
+            },
+        ));
+
+        let result: serde_json::Value = serde_json::from_str(
+            &timeout(Duration::from_secs(1), destroy)
+                .await
+                .expect("destroy should complete")
+                .expect("destroy task should not panic"),
+        )
+        .unwrap();
+        assert_eq!(result["ok"], true);
+        assert_eq!(result["request_id"], request_id);
+        assert_eq!(result["display_id"], 99);
+        assert_eq!(result["capture_generation"], "vdcg-live");
+        assert_eq!(result["closed_browser_workspace_ids"][0], "bw-1");
+    }
+
+    #[tokio::test]
+    async fn virtual_display_destroy_wait_cancellation_fails_closed() {
+        let bus = EventBus::new();
+        let waiter = bus
+            .register_virtual_display_destroy_waiter("vdd-cancelled".to_string())
+            .unwrap();
+        assert!(bus.virtual_display_destroy_is_pending("vdd-cancelled"));
+        assert!(bus
+            .register_virtual_display_destroy_waiter("vdd-cancelled".to_string())
+            .is_err());
+        drop(waiter);
+        assert!(!bus.virtual_display_destroy_is_pending("vdd-cancelled"));
+        assert!(!bus.complete_virtual_display_destroy(
+            "vdd-cancelled",
+            crate::event::VirtualDisplayDestroyOutcome::Refused {
                 reason: "cancelled".to_string(),
             }
         ));

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -5,6 +5,8 @@
 
 use super::*;
 
+const VIRTUAL_DISPLAY_DESTROY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 impl IntendantServer {
     #[tool(
         description = "List browser workspace provider availability for local semantic browser control and streamed fallback."
@@ -156,7 +158,7 @@ impl IntendantServer {
                 width: params.width,
                 height: params.height,
             }));
-        match waiter.wait(std::time::Duration::from_secs(60)).await {
+        match waiter.wait(std::time::Duration::from_secs(20)).await {
             Ok(crate::event::VirtualDisplayCreateOutcome::Created {
                 display_id,
                 width,
@@ -225,7 +227,7 @@ impl IntendantServer {
                 note: params.note,
             },
         ));
-        match waiter.wait(std::time::Duration::from_secs(20)).await {
+        match waiter.wait(VIRTUAL_DISPLAY_DESTROY_TIMEOUT).await {
             Ok(crate::event::VirtualDisplayDestroyOutcome::Destroyed {
                 display_id,
                 capture_generation,
@@ -254,7 +256,10 @@ impl IntendantServer {
                 "request_id": request_id,
                 "display_id": params.display_id,
                 "capture_generation": params.capture_generation,
-                "error": "virtual display destruction did not return its correlated result within 60s"
+                "error": format!(
+                    "virtual display destruction did not return its correlated result within {}s",
+                    VIRTUAL_DISPLAY_DESTROY_TIMEOUT.as_secs()
+                )
             })
             .to_string(),
             Err(crate::event::VirtualDisplayDestroyWaitError::Closed) => serde_json::json!({

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -156,7 +156,7 @@ impl IntendantServer {
                 width: params.width,
                 height: params.height,
             }));
-        match waiter.wait(std::time::Duration::from_secs(20)).await {
+        match waiter.wait(std::time::Duration::from_secs(60)).await {
             Ok(crate::event::VirtualDisplayCreateOutcome::Created {
                 display_id,
                 width,
@@ -254,7 +254,7 @@ impl IntendantServer {
                 "request_id": request_id,
                 "display_id": params.display_id,
                 "capture_generation": params.capture_generation,
-                "error": "virtual display destruction did not return its correlated result within 20s"
+                "error": "virtual display destruction did not return its correlated result within 60s"
             })
             .to_string(),
             Err(crate::event::VirtualDisplayDestroyWaitError::Closed) => serde_json::json!({

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -467,9 +467,11 @@ pub(crate) async fn destroy_virtual_display(
     });
 
     if let Some(session) = session_registry.write().await.remove(display_id) {
-        tokio::spawn(async move {
-            session.stop().await;
-        });
+        // Exact destroy is a receipt-bearing automation primitive, unlike
+        // the latency-sensitive dashboard revoke path. Do not report success
+        // while the old generation still has capture, input, tile, or peer
+        // tasks alive; a subsequent create may reuse the numeric id.
+        session.stop().await;
     }
     guard.shutdown().await;
 

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -473,7 +473,18 @@ pub(crate) async fn destroy_virtual_display(
         // tasks alive; a subsequent create may reuse the numeric id.
         session.stop().await;
     }
-    guard.shutdown().await;
+    if !guard.shutdown().await {
+        let reason = format!(
+            "display :{display_id} generation {capture_generation} shutdown could not be confirmed"
+        );
+        bus.send(AppEvent::PresenceLog {
+            message: format!("[virtual_display] {reason}"),
+            level: Some(LogLevel::Error),
+            turn: None,
+        });
+        refuse_virtual_display_destroy(bus, request_id, reason);
+        return;
+    }
 
     bus.send(AppEvent::PresenceLog {
         message: format!(

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -20,7 +20,7 @@
 
 use crate::display;
 use crate::display_glue::activate_user_display_with_capture_generation;
-use crate::event::{AppEvent, EventBus, VirtualDisplayCreateOutcome};
+use crate::event::{AppEvent, EventBus, VirtualDisplayCreateOutcome, VirtualDisplayDestroyOutcome};
 use crate::frames;
 use crate::types::LogLevel;
 use crate::vision;
@@ -101,6 +101,14 @@ impl VirtualDisplayGuards {
 
     fn get_mut(&mut self, display_id: &u32) -> Option<&mut VirtualDisplayOwnership> {
         self.ownership.get_mut(display_id)
+    }
+
+    fn owns_generation(&self, display_id: u32, capture_generation: &str) -> bool {
+        self.processes.contains_key(&display_id)
+            && self
+                .ownership
+                .get(&display_id)
+                .is_some_and(|ownership| ownership.capture_generation == capture_generation)
     }
 
     fn insert(
@@ -358,6 +366,7 @@ pub(crate) async fn handle_virtual_display_capture_readiness(
             display_id,
             width,
             height,
+            capture_generation: capture_generation.to_string(),
         },
     ) {
         if let Some(ownership) = guards.get_mut(&display_id) {
@@ -376,6 +385,116 @@ pub(crate) async fn handle_virtual_display_capture_readiness(
         )
         .await;
     }
+}
+
+/// Destroy one exact daemon-owned virtual-display generation. The serial
+/// display owner calls this only after the MCP surface registered a waiter.
+/// Both facts matter: a cancelled caller must not leave a delayed destructive
+/// intent behind, and a reused numeric X display id must never let an old job
+/// tear down a replacement.
+pub(crate) async fn destroy_virtual_display(
+    bus: &EventBus,
+    session_registry: &display::SharedSessionRegistry,
+    guards: &mut VirtualDisplayGuards,
+    request_id: &str,
+    display_id: u32,
+    capture_generation: &str,
+    note: Option<&str>,
+) {
+    if !bus.virtual_display_destroy_is_pending(request_id) {
+        eprintln!("[virtual_display] skipped cancelled destroy request {request_id}");
+        return;
+    }
+
+    let Some(ownership) = guards.get(&display_id) else {
+        refuse_virtual_display_destroy(
+            bus,
+            request_id,
+            format!("display :{display_id} is not a daemon-owned virtual display"),
+        );
+        return;
+    };
+    if ownership.capture_generation != capture_generation {
+        refuse_virtual_display_destroy(
+            bus,
+            request_id,
+            format!(
+                "capture generation does not match the live daemon-owned display :{display_id}"
+            ),
+        );
+        return;
+    }
+    if !guards.owns_generation(display_id, capture_generation) {
+        refuse_virtual_display_destroy(
+            bus,
+            request_id,
+            format!("display :{display_id} has incomplete daemon ownership state"),
+        );
+        return;
+    }
+    let Some(guard) = guards.remove(&display_id) else {
+        refuse_virtual_display_destroy(
+            bus,
+            request_id,
+            format!("display :{display_id} ownership changed before teardown"),
+        );
+        return;
+    };
+
+    let context = note
+        .map(str::trim)
+        .filter(|note| !note.is_empty())
+        .unwrap_or("generation-bound destroy requested");
+    let context = crate::types::truncate_str(context, 280);
+
+    // Retire every browser binding before touching capture or Xvfb. The
+    // registry lock also removes bindability, so a new workspace cannot race
+    // into this display after the scan.
+    let closed_browser_workspace_ids =
+        crate::browser_workspace::close_display_binding(display_id, context, bus)
+            .await
+            .into_iter()
+            .map(|workspace| workspace.id)
+            .collect::<Vec<_>>();
+
+    // Publish the old generation's terminal lifecycle before freeing the id.
+    // Its later intent-lane copy carries the generation and is therefore
+    // barred from touching any replacement that reuses the number.
+    bus.send(AppEvent::DisplayCaptureLost {
+        display_id,
+        capture_generation: Some(capture_generation.to_string()),
+        reason: context.to_string(),
+    });
+
+    if let Some(session) = session_registry.write().await.remove(display_id) {
+        tokio::spawn(async move {
+            session.stop().await;
+        });
+    }
+    guard.shutdown().await;
+
+    bus.send(AppEvent::PresenceLog {
+        message: format!(
+            "[virtual_display] destroyed :{display_id} generation {capture_generation} ({context})"
+        ),
+        level: Some(LogLevel::Info),
+        turn: None,
+    });
+    let _ = bus.complete_virtual_display_destroy(
+        request_id,
+        VirtualDisplayDestroyOutcome::Destroyed {
+            display_id,
+            capture_generation: capture_generation.to_string(),
+            closed_browser_workspace_ids,
+        },
+    );
+}
+
+fn refuse_virtual_display_destroy(bus: &EventBus, request_id: &str, reason: String) {
+    let _ = bus.complete_virtual_display_destroy(
+        request_id,
+        VirtualDisplayDestroyOutcome::Refused { reason },
+    );
 }
 
 pub(crate) async fn handle_virtual_display_capture_lost(
@@ -708,6 +827,7 @@ mod tests {
                 display_id: 199,
                 width: 1280,
                 height: 720,
+                capture_generation: "generation-current".to_string(),
             })
         );
         assert_eq!(guards.get(&199).unwrap().request_id, None);
@@ -829,6 +949,83 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn stale_destroy_generation_is_refused_without_touching_live_ownership() {
+        let bus = EventBus::new();
+        let waiter = bus
+            .register_virtual_display_destroy_waiter("vdd-stale".to_string())
+            .unwrap();
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::display::SessionRegistry::new(),
+        ));
+        let mut guards = VirtualDisplayGuards::new();
+        guards.ownership.insert(
+            199,
+            VirtualDisplayOwnership {
+                capture_generation: "generation-live".to_string(),
+                request_id: None,
+                width: 1280,
+                height: 720,
+            },
+        );
+
+        destroy_virtual_display(
+            &bus,
+            &registry,
+            &mut guards,
+            "vdd-stale",
+            199,
+            "generation-old",
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            waiter.wait(Duration::from_millis(100)).await,
+            Ok(VirtualDisplayDestroyOutcome::Refused {
+                reason: "capture generation does not match the live daemon-owned display :199"
+                    .to_string(),
+            })
+        );
+        assert_eq!(
+            guards
+                .get(&199)
+                .map(|ownership| ownership.capture_generation.as_str()),
+            Some("generation-live")
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_destroy_request_performs_no_teardown() {
+        let bus = EventBus::new();
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::display::SessionRegistry::new(),
+        ));
+        let mut guards = VirtualDisplayGuards::new();
+        guards.ownership.insert(
+            199,
+            VirtualDisplayOwnership {
+                capture_generation: "generation-live".to_string(),
+                request_id: None,
+                width: 1280,
+                height: 720,
+            },
+        );
+
+        destroy_virtual_display(
+            &bus,
+            &registry,
+            &mut guards,
+            "vdd-cancelled",
+            199,
+            "generation-live",
+            None,
+        )
+        .await;
+
+        assert!(guards.get(&199).is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- return an opaque capture generation from each correlated virtual-display create
- add an MCP/CLI-only synchronous destroy operation that requires both display id and generation
- retire bound browsers before capture and Xvfb teardown, while refusing stale generations without side effects

## Safety properties

- numeric display-id reuse cannot make an old cleanup destroy a replacement
- cancelled/unregistered destroy requests are ignored before teardown
- the operation is not advertised on the dashboard RPC lane because its request correlation is daemon-internal
- hosted-control remains denied; existing display-input authorization applies

## Validation

- cargo test -p intendant --bins (6,078 controller tests plus runtime bin tests)
- cargo test -p intendant-core -p intendant-custody -p intendant-display -p intendant-platform -p owner-plane-core -p owner-plane-reducer
- cargo test -p intendant --test e2e (55 tests)
- cargo clippy --workspace -- -D warnings
- cargo check --bin intendant
- cargo fmt --all -- --check
- git diff --check