### PR TITLE
Add bounded computer-use proof task receipts

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -24,7 +24,7 @@
 //! - `latest_frame`: always overwritten, latest-wins.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -1398,6 +1398,11 @@ pub struct DisplaySession {
     /// `enqueue_input` path (spawn) and briefly from async `stop()`
     /// (join) — never held across an await.
     input_pump_handle: std::sync::Mutex<Option<JoinHandle<()>>>,
+    /// 0 = browser interactive lanes open, 1 = sealing, 2 = sealed, 3 =
+    /// failed sealing. Proof automation permanently seals its ephemeral
+    /// display before direct input; every existing and future browser-input
+    /// or clipboard predicate observes this shared state.
+    browser_interactive_seal_state: Arc<AtomicU8>,
     /// Wakes the pool-feed bridge to open a peer-join burst window
     /// when a new pool peer attaches. `Some` after
     /// [`Self::spawn_pool_feed_bridge`] has run (eagerly from
@@ -2180,6 +2185,7 @@ impl DisplaySession {
             input_queue: Arc::new(input_queue::InputQueue::new()),
             input_pump_started: AtomicBool::new(false),
             input_pump_handle: std::sync::Mutex::new(None),
+            browser_interactive_seal_state: Arc::new(AtomicU8::new(0)),
             pool_feed_keyframe_tx: Mutex::new(None),
             pool: std::sync::OnceLock::new(),
             pool_feed_bridge_handle: Mutex::new(None),
@@ -3401,9 +3407,12 @@ impl DisplaySession {
         // must also make every input/clipboard callback fail closed during
         // that short pre-registration window.
         let shutdown_for_interactive = self.shutdown.clone();
+        let seal_state_for_interactive = Arc::clone(&self.browser_interactive_seal_state);
         let external_interactive_predicate = Arc::clone(&interactive_authorized.predicate);
         let interactive_authorized = interactive_authorized.with_predicate(Arc::new(move || {
-            !shutdown_for_interactive.is_cancelled() && external_interactive_predicate()
+            !shutdown_for_interactive.is_cancelled()
+                && seal_state_for_interactive.load(Ordering::SeqCst) == 0
+                && external_interactive_predicate()
         }));
         let peer_alive = Arc::new(AtomicBool::new(true));
         let peer_lifecycle_gate = Arc::new(std::sync::RwLock::new(true));
@@ -4752,7 +4761,82 @@ impl DisplaySession {
         input_authorized: BrowserInputAuthorization,
     ) -> Arc<BrowserInputSource> {
         self.ensure_input_pump();
+        let seal_state = Arc::clone(&self.browser_interactive_seal_state);
+        let external_predicate = Arc::clone(&input_authorized.predicate);
+        let input_authorized = input_authorized.with_predicate(Arc::new(move || {
+            seal_state.load(Ordering::SeqCst) == 0 && external_predicate()
+        }));
         BrowserInputSource::new(&self.input_queue, input_authorized)
+    }
+
+    /// Permanently seal browser-originated input and clipboard mutation for
+    /// this ephemeral display, drain the ordered input pump, and wait for its
+    /// safety releases before proof automation injects direct CU actions.
+    /// Idempotent after a successful seal; a failed seal remains failed
+    /// closed and requires recreating the display session.
+    pub async fn seal_browser_interactive_for_automation(
+        &self,
+        reason: &str,
+    ) -> Result<(), CallerError> {
+        match self.browser_interactive_seal_state.compare_exchange(
+            0,
+            1,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => {}
+            Err(2) => return Ok(()),
+            Err(1) => {
+                return Err(CallerError::Display(
+                    "browser interactive sealing is already in progress".to_string(),
+                ));
+            }
+            Err(_) => {
+                return Err(CallerError::Display(
+                    "browser interactive sealing previously failed; recreate the display session"
+                        .to_string(),
+                ));
+            }
+        }
+
+        self.input_queue.trip(reason);
+        let input_pump = self
+            .input_pump_handle
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+        let Some(mut input_pump) = input_pump else {
+            self.browser_interactive_seal_state
+                .store(2, Ordering::SeqCst);
+            return Ok(());
+        };
+        const SEAL_TIMEOUT: Duration = Duration::from_secs(2);
+        match tokio::time::timeout(SEAL_TIMEOUT, &mut input_pump).await {
+            Ok(Ok(())) => {
+                self.browser_interactive_seal_state
+                    .store(2, Ordering::SeqCst);
+                Ok(())
+            }
+            Ok(Err(error)) => {
+                self.browser_interactive_seal_state
+                    .store(3, Ordering::SeqCst);
+                Err(CallerError::Display(format!(
+                    "browser input pump failed while sealing proof display: {error}"
+                )))
+            }
+            Err(_) => {
+                *self
+                    .input_pump_handle
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner()) = Some(input_pump);
+                self.browser_interactive_seal_state
+                    .store(3, Ordering::SeqCst);
+                Err(CallerError::Display(format!(
+                    "browser input pump did not seal within {}s; recreate the display session",
+                    SEAL_TIMEOUT.as_secs()
+                )))
+            }
+        }
     }
 
     /// Fail browser-originated input closed for this display session and wake
@@ -8251,6 +8335,42 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), session.stop())
             .await
             .expect("stop must tear down the backend instead of deadlocking on injection");
+    }
+
+    #[tokio::test]
+    async fn automation_seal_drains_and_permanently_blocks_browser_interactive_input() {
+        let (injected_tx, mut injected_rx) = mpsc::unbounded_channel();
+        let session = DisplaySession::new(
+            0,
+            Arc::new(SourceRecordingBackend {
+                injected: injected_tx,
+            }),
+        );
+        let existing =
+            session.browser_input_source(BrowserInputAuthorization::new(Arc::new(|| true)));
+        existing.enqueue(test_key_down());
+        assert_eq!(injected_rx.recv().await, Some("kd"));
+
+        session
+            .seal_browser_interactive_for_automation("unit-test proof seal")
+            .await
+            .unwrap();
+        assert_eq!(injected_rx.recv().await, Some("ku"));
+        session
+            .seal_browser_interactive_for_automation("idempotent proof seal")
+            .await
+            .unwrap();
+
+        existing.enqueue(test_key_down());
+        let future =
+            session.browser_input_source(BrowserInputAuthorization::new(Arc::new(|| true)));
+        future.enqueue(test_key_down());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), injected_rx.recv())
+                .await
+                .is_err()
+        );
+        session.stop().await;
     }
 
     // -----------------------------------------------------------------------

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) mod input_queue;
 /// display session's ordered browser-input queue. Keeping one exported value
 /// prevents the transport shim from growing a larger hidden backlog.
 pub const BROWSER_INPUT_QUEUE_HARD_CAP: usize = input_queue::INPUT_QUEUE_HARD_CAP;
+const BROWSER_CLIPBOARD_TASK_HARD_CAP: usize = 64;
 pub mod input_telemetry;
 pub mod keymap;
 #[cfg(target_os = "macos")]
@@ -1383,6 +1384,11 @@ pub struct DisplaySession {
     clipboard_monitor: Arc<clipboard::ClipboardMonitor>,
     /// Handle for the clipboard forwarding task (remote -> browser).
     clipboard_handle: Mutex<Option<JoinHandle<()>>>,
+    /// Browser-to-system clipboard mutations already admitted by a live
+    /// interactive authority. A synchronous mutex makes admission + task
+    /// registration atomic with proof sealing; sealing then drains every
+    /// admitted mutation before direct automation begins.
+    browser_clipboard_tasks: Arc<std::sync::Mutex<Vec<JoinHandle<()>>>>,
     /// Ordered browser-input queue (see [`input_queue`]). Every browser
     /// input lane — the WebRTC data channels, the dashboard-control
     /// tunnel, and the legacy `/ws` socket — enqueues here via
@@ -2182,6 +2188,7 @@ impl DisplaySession {
             metrics_epoch: Mutex::new(Instant::now()),
             clipboard_monitor: Arc::new(clipboard::ClipboardMonitor::new()),
             clipboard_handle: Mutex::new(None),
+            browser_clipboard_tasks: Arc::new(std::sync::Mutex::new(Vec::new())),
             input_queue: Arc::new(input_queue::InputQueue::new()),
             input_pump_started: AtomicBool::new(false),
             input_pump_handle: std::sync::Mutex::new(None),
@@ -2877,6 +2884,12 @@ impl DisplaySession {
                 }
             }
         }
+        if let Err(error) = self
+            .drain_browser_clipboard_mutations(Duration::from_secs(2))
+            .await
+        {
+            eprintln!("[display/clipboard] shutdown drain failed: {error}");
+        }
         if !backend_stopped {
             self.backend.stop_capture().await;
         }
@@ -3433,17 +3446,28 @@ impl DisplaySession {
         let authority_handler = lifecycle_gated_authority_handler(&input_source, authority_handler);
 
         let clipboard_monitor = Arc::clone(&self.clipboard_monitor);
+        let browser_clipboard_tasks = Arc::clone(&self.browser_clipboard_tasks);
         let clipboard_authorized = interactive_authorization.clone();
         let clipboard_authorized_for_handler = interactive_authorization;
         let clipboard_handler: Arc<dyn Fn(clipboard::ClipboardContent) + Send + Sync> =
             Arc::new(move |content: clipboard::ClipboardContent| {
+                let mut tasks = browser_clipboard_tasks
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                tasks.retain(|task| !task.is_finished());
+                if tasks.len() >= BROWSER_CLIPBOARD_TASK_HARD_CAP {
+                    eprintln!(
+                        "[display/clipboard] refused browser clipboard mutation: task cap reached"
+                    );
+                    return;
+                }
                 let Ok(admitted_revision) = clipboard_authorized_for_handler.admission_revision()
                 else {
                     return;
                 };
                 let monitor = Arc::clone(&clipboard_monitor);
                 let still_authorized = clipboard_authorized_for_handler.clone();
-                tokio::spawn(async move {
+                let task = tokio::spawn(async move {
                     // The task may sit behind unrelated runtime work after the
                     // data-channel callback returns. Re-check at the mutation
                     // boundary so revocation/teardown in that window wins.
@@ -3463,6 +3487,7 @@ impl DisplaySession {
                         }
                     }
                 });
+                tasks.push(task);
             });
         let tile_control_handler = self.build_tile_control_handler(peer_id);
 
@@ -4805,37 +4830,86 @@ impl DisplaySession {
             .lock()
             .unwrap_or_else(|error| error.into_inner())
             .take();
-        let Some(mut input_pump) = input_pump else {
-            self.browser_interactive_seal_state
-                .store(2, Ordering::SeqCst);
-            return Ok(());
-        };
         const SEAL_TIMEOUT: Duration = Duration::from_secs(2);
-        match tokio::time::timeout(SEAL_TIMEOUT, &mut input_pump).await {
-            Ok(Ok(())) => {
-                self.browser_interactive_seal_state
-                    .store(2, Ordering::SeqCst);
-                Ok(())
+        if let Some(mut input_pump) = input_pump {
+            match tokio::time::timeout(SEAL_TIMEOUT, &mut input_pump).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    self.browser_interactive_seal_state
+                        .store(3, Ordering::SeqCst);
+                    return Err(CallerError::Display(format!(
+                        "browser input pump failed while sealing proof display: {error}"
+                    )));
+                }
+                Err(_) => {
+                    *self
+                        .input_pump_handle
+                        .lock()
+                        .unwrap_or_else(|error| error.into_inner()) = Some(input_pump);
+                    self.browser_interactive_seal_state
+                        .store(3, Ordering::SeqCst);
+                    return Err(CallerError::Display(format!(
+                        "browser input pump did not seal within {}s; recreate the display session",
+                        SEAL_TIMEOUT.as_secs()
+                    )));
+                }
             }
-            Ok(Err(error)) => {
-                self.browser_interactive_seal_state
-                    .store(3, Ordering::SeqCst);
-                Err(CallerError::Display(format!(
-                    "browser input pump failed while sealing proof display: {error}"
-                )))
+        }
+        if let Err(error) = self.drain_browser_clipboard_mutations(SEAL_TIMEOUT).await {
+            self.browser_interactive_seal_state
+                .store(3, Ordering::SeqCst);
+            return Err(error);
+        }
+        self.browser_interactive_seal_state
+            .store(2, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn drain_browser_clipboard_mutations(
+        &self,
+        timeout: Duration,
+    ) -> Result<(), CallerError> {
+        let mut tasks = std::mem::take(
+            &mut *self
+                .browser_clipboard_tasks
+                .lock()
+                .unwrap_or_else(|error| error.into_inner()),
+        );
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut errors = Vec::new();
+        for index in 0..tasks.len() {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let outcome = if remaining.is_zero() {
+                None
+            } else {
+                tokio::time::timeout(remaining, &mut tasks[index])
+                    .await
+                    .ok()
+            };
+            match outcome {
+                Some(Ok(())) => {}
+                Some(Err(error)) => errors.push(error.to_string()),
+                None => {
+                    for task in tasks.iter().skip(index) {
+                        task.abort();
+                    }
+                    for task in tasks.iter_mut().skip(index) {
+                        let _ = task.await;
+                    }
+                    return Err(CallerError::Display(format!(
+                        "browser clipboard mutations did not drain within {}s",
+                        timeout.as_secs()
+                    )));
+                }
             }
-            Err(_) => {
-                *self
-                    .input_pump_handle
-                    .lock()
-                    .unwrap_or_else(|error| error.into_inner()) = Some(input_pump);
-                self.browser_interactive_seal_state
-                    .store(3, Ordering::SeqCst);
-                Err(CallerError::Display(format!(
-                    "browser input pump did not seal within {}s; recreate the display session",
-                    SEAL_TIMEOUT.as_secs()
-                )))
-            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(CallerError::Display(format!(
+                "browser clipboard mutation task failed while sealing: {}",
+                errors.join("; ")
+            )))
         }
     }
 
@@ -8370,6 +8444,52 @@ mod tests {
                 .await
                 .is_err()
         );
+        session.stop().await;
+    }
+
+    #[tokio::test]
+    async fn automation_seal_waits_for_every_admitted_browser_clipboard_mutation() {
+        let (injected_tx, _injected_rx) = mpsc::unbounded_channel();
+        let session = Arc::new(DisplaySession::new(
+            0,
+            Arc::new(SourceRecordingBackend {
+                injected: injected_tx,
+            }),
+        ));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let finished = Arc::new(AtomicBool::new(false));
+        let task = {
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            let finished = Arc::clone(&finished);
+            tokio::spawn(async move {
+                started.notify_one();
+                release.notified().await;
+                finished.store(true, Ordering::SeqCst);
+            })
+        };
+        session
+            .browser_clipboard_tasks
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(task);
+        started.notified().await;
+
+        let sealing = {
+            let session = Arc::clone(&session);
+            tokio::spawn(async move {
+                session
+                    .seal_browser_interactive_for_automation("clipboard drain test")
+                    .await
+            })
+        };
+        tokio::task::yield_now().await;
+        assert!(!sealing.is_finished());
+        assert!(!finished.load(Ordering::SeqCst));
+        release.notify_one();
+        sealing.await.unwrap().unwrap();
+        assert!(finished.load(Ordering::SeqCst));
         session.stop().await;
     }
 

--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -1779,6 +1779,14 @@ pub fn is_root() -> bool {
     }
 }
 
+/// Effective Unix user id for ownership checks performed by higher-level
+/// safe Rust. Keep the libc probe inside this documented platform island.
+#[cfg(unix)]
+pub fn unix_effective_uid() -> u32 {
+    // SAFETY: geteuid takes no arguments and cannot fail.
+    unsafe { libc::geteuid() }
+}
+
 /// The calling user's uid, for launchd's `gui/<uid>/…` service targets.
 #[cfg(unix)]
 pub fn unix_uid() -> u32 {

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -108,6 +108,16 @@ The daemon rechecks the exact display generation and browser lease around each
 action, serializes tasks per display generation, and deletes its mode-0700
 scratch directory before returning.
 
+The 180-second `stage` and 45-second `attest` deadlines begin at request
+admission, including any wait for exclusive display control and all setup. A
+ready workspace is also probed for a live daemon-owned browser child and its
+exact CDP page target around every action. The initial model frame must have
+been captured after browser-originated input was permanently sealed. Text,
+scroll, hold, and wait parameters carry fixed per-action caps; if a platform
+operation has already entered non-abortable OS work when the deadline fires,
+it retains the exclusive display and private scratch lifetimes until that
+bounded work finishes.
+
 Successful calls return a compact receipt rather than screenshots or typed
 text. Its identity binds the exact resources, provider/model, timestamps and
 monotonic elapsed time, task and normalized-result hashes, every model-visible

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -95,6 +95,27 @@ element): multi-line/control text (Return may submit, Tab may move focus),
 secure fields, and elements without an AX-readable value stay `injected`
 with the reason in the result detail.
 
+### Bounded proof tasks
+
+`intendant ctl cu task` is the owner-only orchestration lane for evidence
+capture on an exact daemon-created virtual-display generation and exact
+attempt-leased local CDP browser workspace. It is deliberately smaller than
+an agent session: the selected provider receives native CU plus no function
+tools, shell, filesystem, browser API, delegation, or escalation capability.
+`stage` has fixed turn/action/time limits and may operate the isolated display;
+`attest` receives one internally captured PNG and refuses every later action.
+The daemon rechecks the exact display generation and browser lease around each
+action, serializes tasks per display generation, and deletes its mode-0700
+scratch directory before returning.
+
+Successful calls return a compact receipt rather than screenshots or typed
+text. Its identity binds the exact resources, provider/model, timestamps and
+monotonic elapsed time, task and normalized-result hashes, every model-visible
+frame hash, action-kind/payload hashes and counters, plus the prior stage and
+observation lineage required by `attest`. Scoped agent callers are rejected;
+the intended caller is a local owner-side orchestrator using the loopback
+`intendant ctl` lane.
+
 **Typing on macOS**: ASCII is delivered as real ANSI-US keycode events (the
 same proven event shape as `key`), newlines as Return and tabs as Tab;
 characters with no ANSI-US key are delivered as paced unicode-string events

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -366,6 +366,7 @@ claim instead.
 | `read_screen`        | User session's frontmost-app accessibility tree — macOS AX, Linux AT-SPI, or Windows UIA. | `display_target?`, `format?`, `full_values?` |
 | `display_readiness`  | Probe display authority, capture/accessibility permission, target availability, and input backend live; names each missing layer. | `display_target?` |
 | `execute_cu_actions` | Run a batch of [computer-use](./computer-use-and-audio.md) actions. | CU action params |
+| `run_bounded_cu_task` | Run an owner-only synchronous, fixed-budget CU-only task on one exact daemon-owned virtual-display generation and attempt-leased local CDP workspace. `stage` permits native CU actions but exposes no function tools or escalation; `attest` supplies one internally captured frame and rejects every subsequent action. The compact receipt binds the exact resources, provider/model, timestamps, task/result hashes, transcript lineage, and action counters. | `mode`, `attempt_id`, `workspace_id`, `display_id`, `display_target`, `capture_generation`, `task`, attestation lineage fields? |
 | `list_frames`        | List captured video frames. | filter params |
 | `read_frame`         | Read a specific frame. | `frame_id` |
 

--- a/src/bin/caller/bounded_cu_task.rs
+++ b/src/bin/caller/bounded_cu_task.rs
@@ -212,7 +212,9 @@ fn issued_stage_receipts() -> &'static std::sync::Mutex<VecDeque<BoundedCuTaskRe
     RECEIPTS.get_or_init(|| std::sync::Mutex::new(VecDeque::new()))
 }
 
-fn remember_issued_stage_receipt(receipt: &BoundedCuTaskReceipt) -> Result<(), BoundedCuTaskError> {
+pub(crate) fn remember_issued_stage_receipt(
+    receipt: &BoundedCuTaskReceipt,
+) -> Result<(), BoundedCuTaskError> {
     let mut receipts = issued_stage_receipts().lock().map_err(|_| {
         BoundedCuTaskError::new(
             "bounded-cu-receipt-registry-unavailable",
@@ -292,14 +294,8 @@ pub(crate) async fn run_bounded_cu_task(
         bind_issued_stage_receipt(&mut request)?;
     }
     let timeout = request.mode.timeout();
-    let mode = request.mode;
     match tokio::time::timeout(timeout, run_inner(provider, executor, request)).await {
-        Ok(Ok(receipt)) => {
-            if mode == BoundedCuTaskMode::Stage {
-                remember_issued_stage_receipt(&receipt)?;
-            }
-            Ok(receipt)
-        }
+        Ok(Ok(receipt)) => Ok(receipt),
         Ok(Err(error)) => Err(error),
         Err(_) => Err(BoundedCuTaskError::new(
             "bounded-cu-deadline-exceeded",
@@ -489,6 +485,18 @@ async fn apply_cu_calls(
             return Err(BoundedCuTaskError::new(
                 "bounded-cu-paste-refused",
                 "clipboard paste is not permitted in the bounded proof lane; use typed input",
+                false,
+            ));
+        }
+        if call.actions.iter().any(|action| {
+            matches!(
+                action,
+                CuAction::MouseDown { .. } | CuAction::MouseUp { .. }
+            )
+        }) {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-split-input-edge-refused",
+                "split mouse down/up actions are not permitted in the bounded proof lane",
                 false,
             ));
         }
@@ -1142,9 +1150,11 @@ mod tests {
     async fn issue_stage_receipt() -> BoundedCuTaskReceipt {
         let provider = FakeProvider::new(vec![response(r#"{"ready":true}"#)]);
         let mut executor = FakeExecutor::default();
-        run_bounded_cu_task(&provider, &mut executor, stage_request())
+        let receipt = run_bounded_cu_task(&provider, &mut executor, stage_request())
             .await
-            .unwrap()
+            .unwrap();
+        remember_issued_stage_receipt(&receipt).unwrap();
+        receipt
     }
 
     #[tokio::test]
@@ -1313,6 +1323,28 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(error.code, "bounded-cu-paste-refused");
+        assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
+    #[tokio::test]
+    async fn split_mouse_edges_are_rejected_before_input() {
+        let mut action_response = response("");
+        action_response.cu_calls.push(CuToolCall {
+            call_id: "cu-mouse-down".to_string(),
+            actions: vec![CuAction::MouseDown {
+                x: 10,
+                y: 20,
+                button: MouseButton::Left,
+            }],
+            metadata: CuCallMetadata::default(),
+        });
+        let provider = FakeProvider::new(vec![action_response]);
+        let mut executor = FakeExecutor::default();
+        let error = run_bounded_cu_task(&provider, &mut executor, stage_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "bounded-cu-split-input-edge-refused");
         assert_eq!(executor.batches, vec![vec!["screenshot"]]);
     }
 

--- a/src/bin/caller/bounded_cu_task.rs
+++ b/src/bin/caller/bounded_cu_task.rs
@@ -24,6 +24,11 @@ pub(crate) const BOUNDED_CU_MAX_RESULT_BYTES: usize = 16 * 1024;
 const BOUNDED_CU_MAX_BATCH_ACTIONS: usize = 16;
 const BOUNDED_CU_MAX_TOTAL_ACTIONS: u64 = 64;
 const BOUNDED_CU_MAX_ACTION_PAYLOAD_BYTES: usize = 64 * 1024;
+const BOUNDED_CU_MAX_TYPE_BYTES: usize = 4 * 1024;
+const BOUNDED_CU_MAX_KEY_BYTES: usize = 256;
+const BOUNDED_CU_MAX_SCROLL_TICKS: i32 = 100;
+const BOUNDED_CU_MAX_HOLD_MS: u64 = 5_000;
+const BOUNDED_CU_MAX_WAIT_MS: u64 = 5_000;
 const BOUNDED_CU_STAGE_MAX_TURNS: u32 = 12;
 const BOUNDED_CU_ATTEST_MAX_TURNS: u32 = 2;
 const BOUNDED_CU_STAGE_TIMEOUT: Duration = Duration::from_secs(180);
@@ -46,7 +51,7 @@ impl BoundedCuTaskMode {
         }
     }
 
-    fn timeout(self) -> Duration {
+    pub(crate) fn timeout(self) -> Duration {
         match self {
             Self::Stage => BOUNDED_CU_STAGE_TIMEOUT,
             Self::Attest => BOUNDED_CU_ATTEST_TIMEOUT,
@@ -58,6 +63,17 @@ impl BoundedCuTaskMode {
             Self::Stage => "stage",
             Self::Attest => "attest",
         }
+    }
+
+    pub(crate) fn deadline_error(self) -> BoundedCuTaskError {
+        BoundedCuTaskError::new(
+            "bounded-cu-deadline-exceeded",
+            format!(
+                "bounded CU task exceeded its fixed {}s deadline",
+                self.timeout().as_secs()
+            ),
+            true,
+        )
     }
 }
 
@@ -284,27 +300,35 @@ fn bind_issued_stage_receipt(request: &mut BoundedCuTaskRequest) -> Result<(), B
 }
 
 /// Run one strictly bounded CU-only task.
+#[cfg(test)]
 pub(crate) async fn run_bounded_cu_task(
     provider: &dyn ChatProvider,
     executor: &mut dyn BoundedCuActionExecutor,
+    request: BoundedCuTaskRequest,
+) -> Result<BoundedCuTaskReceipt, BoundedCuTaskError> {
+    let deadline = tokio::time::Instant::now() + request.mode.timeout();
+    run_bounded_cu_task_until(provider, executor, request, deadline).await
+}
+
+/// Run against a deadline established by the caller at request admission.
+/// The owner-facing lane uses this form so waiting for display exclusivity,
+/// resource probes, provider setup, execution, and finalization all share one
+/// fixed budget instead of restarting the clock after setup.
+pub(crate) async fn run_bounded_cu_task_until(
+    provider: &dyn ChatProvider,
+    executor: &mut dyn BoundedCuActionExecutor,
     mut request: BoundedCuTaskRequest,
+    deadline: tokio::time::Instant,
 ) -> Result<BoundedCuTaskReceipt, BoundedCuTaskError> {
     validate_bounded_cu_task_request(&request)?;
     if request.mode == BoundedCuTaskMode::Attest {
         bind_issued_stage_receipt(&mut request)?;
     }
-    let timeout = request.mode.timeout();
-    match tokio::time::timeout(timeout, run_inner(provider, executor, request)).await {
+    let mode = request.mode;
+    match tokio::time::timeout_at(deadline, run_inner(provider, executor, request)).await {
         Ok(Ok(receipt)) => Ok(receipt),
         Ok(Err(error)) => Err(error),
-        Err(_) => Err(BoundedCuTaskError::new(
-            "bounded-cu-deadline-exceeded",
-            format!(
-                "bounded CU task exceeded its fixed {}s deadline",
-                timeout.as_secs()
-            ),
-            true,
-        )),
+        Err(_) => Err(mode.deadline_error()),
     }
 }
 
@@ -517,6 +541,9 @@ async fn apply_cu_calls(
                 false,
             ));
         }
+        for action in &call.actions {
+            validate_bounded_action(action)?;
+        }
         let payload_bytes = serde_json::to_vec(&call.actions).map_err(|error| {
             BoundedCuTaskError::new(
                 "bounded-cu-action-serialization-failed",
@@ -613,6 +640,28 @@ async fn apply_cu_calls(
         );
     }
     Ok(())
+}
+
+fn validate_bounded_action(action: &CuAction) -> Result<(), BoundedCuTaskError> {
+    let invalid = match action {
+        CuAction::Type { text } => text.len() > BOUNDED_CU_MAX_TYPE_BYTES,
+        CuAction::Key { key } => key.is_empty() || key.len() > BOUNDED_CU_MAX_KEY_BYTES,
+        CuAction::HoldKey { key, ms } => {
+            key.is_empty() || key.len() > BOUNDED_CU_MAX_KEY_BYTES || *ms > BOUNDED_CU_MAX_HOLD_MS
+        }
+        CuAction::Scroll { amount, .. } => !(1..=BOUNDED_CU_MAX_SCROLL_TICKS).contains(amount),
+        CuAction::Wait { ms } => *ms > BOUNDED_CU_MAX_WAIT_MS,
+        _ => false,
+    };
+    if invalid {
+        Err(BoundedCuTaskError::new(
+            "bounded-cu-action-parameter-invalid",
+            "native computer action exceeded a fixed text, key, scroll, hold, or wait bound",
+            false,
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 struct ReceiptCompletion {
@@ -1346,6 +1395,57 @@ mod tests {
 
         assert_eq!(error.code, "bounded-cu-split-input-edge-refused");
         assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
+    #[test]
+    fn bounded_action_parameters_cap_non_abortable_work() {
+        for action in [
+            CuAction::Type {
+                text: "x".repeat(BOUNDED_CU_MAX_TYPE_BYTES + 1),
+            },
+            CuAction::Key {
+                key: "x".repeat(BOUNDED_CU_MAX_KEY_BYTES + 1),
+            },
+            CuAction::HoldKey {
+                key: "a".to_string(),
+                ms: BOUNDED_CU_MAX_HOLD_MS + 1,
+            },
+            CuAction::Scroll {
+                x: 0,
+                y: 0,
+                direction: crate::computer_use::ScrollDirection::Down,
+                amount: BOUNDED_CU_MAX_SCROLL_TICKS + 1,
+            },
+            CuAction::Wait {
+                ms: BOUNDED_CU_MAX_WAIT_MS + 1,
+            },
+        ] {
+            assert_eq!(
+                validate_bounded_action(&action).unwrap_err().code,
+                "bounded-cu-action-parameter-invalid"
+            );
+        }
+
+        for action in [
+            CuAction::Type {
+                text: "x".repeat(BOUNDED_CU_MAX_TYPE_BYTES),
+            },
+            CuAction::HoldKey {
+                key: "a".to_string(),
+                ms: BOUNDED_CU_MAX_HOLD_MS,
+            },
+            CuAction::Scroll {
+                x: 0,
+                y: 0,
+                direction: crate::computer_use::ScrollDirection::Down,
+                amount: BOUNDED_CU_MAX_SCROLL_TICKS,
+            },
+            CuAction::Wait {
+                ms: BOUNDED_CU_MAX_WAIT_MS,
+            },
+        ] {
+            validate_bounded_action(&action).unwrap();
+        }
     }
 
     #[test]

--- a/src/bin/caller/bounded_cu_task.rs
+++ b/src/bin/caller/bounded_cu_task.rs
@@ -12,7 +12,7 @@ use base64::Engine as _;
 use serde::de::{self, DeserializeSeed as _, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
 use crate::computer_use::{CuAction, CuActionStatus};
@@ -29,6 +29,7 @@ const BOUNDED_CU_ATTEST_MAX_TURNS: u32 = 2;
 const BOUNDED_CU_STAGE_TIMEOUT: Duration = Duration::from_secs(180);
 const BOUNDED_CU_ATTEST_TIMEOUT: Duration = Duration::from_secs(45);
 const MAX_BINDING_BYTES: usize = 256;
+const BOUNDED_CU_MAX_ISSUED_STAGE_RECEIPTS: usize = 1_024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -73,6 +74,7 @@ pub(crate) struct BoundedCuTaskRequest {
     pub(crate) prior_transcript_event_count: Option<u64>,
     pub(crate) prior_transcript_sha256: Option<String>,
     pub(crate) observation_sha256: Option<String>,
+    pub(crate) prior_completed_at: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -204,16 +206,101 @@ impl TaskCounters {
     }
 }
 
+fn issued_stage_receipts() -> &'static std::sync::Mutex<VecDeque<BoundedCuTaskReceipt>> {
+    static RECEIPTS: std::sync::OnceLock<std::sync::Mutex<VecDeque<BoundedCuTaskReceipt>>> =
+        std::sync::OnceLock::new();
+    RECEIPTS.get_or_init(|| std::sync::Mutex::new(VecDeque::new()))
+}
+
+fn remember_issued_stage_receipt(receipt: &BoundedCuTaskReceipt) -> Result<(), BoundedCuTaskError> {
+    let mut receipts = issued_stage_receipts().lock().map_err(|_| {
+        BoundedCuTaskError::new(
+            "bounded-cu-receipt-registry-unavailable",
+            "issued stage receipt registry was poisoned",
+            false,
+        )
+    })?;
+    receipts.retain(|existing| existing.receipt_id != receipt.receipt_id);
+    receipts.push_back(receipt.clone());
+    while receipts.len() > BOUNDED_CU_MAX_ISSUED_STAGE_RECEIPTS {
+        receipts.pop_front();
+    }
+    Ok(())
+}
+
+fn bind_issued_stage_receipt(request: &mut BoundedCuTaskRequest) -> Result<(), BoundedCuTaskError> {
+    let prior_receipt_id = request.prior_receipt_id.as_deref().ok_or_else(|| {
+        BoundedCuTaskError::new(
+            "bounded-cu-attestation-lineage-invalid",
+            "attest mode requires an issued stage receipt ID",
+            false,
+        )
+    })?;
+    let prior = issued_stage_receipts()
+        .lock()
+        .map_err(|_| {
+            BoundedCuTaskError::new(
+                "bounded-cu-receipt-registry-unavailable",
+                "issued stage receipt registry was poisoned",
+                false,
+            )
+        })?
+        .iter()
+        .find(|receipt| receipt.receipt_id == prior_receipt_id)
+        .cloned()
+        .ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-prior-receipt-not-issued",
+                "the referenced stage receipt was not issued by this daemon lifetime",
+                false,
+            )
+        })?;
+    if prior.schema_version != 1
+        || prior.mode != BoundedCuTaskMode::Stage
+        || receipt_id(&prior)? != prior.receipt_id
+        || prior.attempt_id != request.attempt_id
+        || prior.workspace_id != request.workspace_id
+        || prior.display_id != request.display_id
+        || prior.display_target != request.display_target
+        || prior.capture_generation != request.capture_generation
+        || prior.prior_receipt_id.is_some()
+        || prior.prior_transcript_event_count.is_some()
+        || prior.prior_transcript_sha256.is_some()
+        || prior.observation_sha256.is_some()
+        || prior.current_transcript_event_count != prior.transcript_event_count
+    {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-prior-receipt-binding-mismatch",
+            "issued stage receipt did not match the exact attempt, workspace, and display generation",
+            false,
+        ));
+    }
+    request.prior_transcript_event_count = Some(prior.transcript_event_count);
+    request.prior_transcript_sha256 = Some(prior.transcript_sha256);
+    request.prior_completed_at = Some(prior.completed_at);
+    Ok(())
+}
+
 /// Run one strictly bounded CU-only task.
 pub(crate) async fn run_bounded_cu_task(
     provider: &dyn ChatProvider,
     executor: &mut dyn BoundedCuActionExecutor,
-    request: BoundedCuTaskRequest,
+    mut request: BoundedCuTaskRequest,
 ) -> Result<BoundedCuTaskReceipt, BoundedCuTaskError> {
     validate_bounded_cu_task_request(&request)?;
+    if request.mode == BoundedCuTaskMode::Attest {
+        bind_issued_stage_receipt(&mut request)?;
+    }
     let timeout = request.mode.timeout();
+    let mode = request.mode;
     match tokio::time::timeout(timeout, run_inner(provider, executor, request)).await {
-        Ok(result) => result,
+        Ok(Ok(receipt)) => {
+            if mode == BoundedCuTaskMode::Stage {
+                remember_issued_stage_receipt(&receipt)?;
+            }
+            Ok(receipt)
+        }
+        Ok(Err(error)) => Err(error),
         Err(_) => Err(BoundedCuTaskError::new(
             "bounded-cu-deadline-exceeded",
             format!(
@@ -228,7 +315,7 @@ pub(crate) async fn run_bounded_cu_task(
 async fn run_inner(
     provider: &dyn ChatProvider,
     executor: &mut dyn BoundedCuActionExecutor,
-    request: BoundedCuTaskRequest,
+    mut request: BoundedCuTaskRequest,
 ) -> Result<BoundedCuTaskReceipt, BoundedCuTaskError> {
     if !provider.cu_enabled() {
         return Err(BoundedCuTaskError::new(
@@ -238,6 +325,23 @@ async fn run_inner(
         ));
     }
     let started_at = now_rfc3339();
+    if let Some(prior_completed_at) = request.prior_completed_at.as_deref() {
+        let prior = chrono::DateTime::parse_from_rfc3339(prior_completed_at).map_err(|_| {
+            BoundedCuTaskError::new(
+                "bounded-cu-prior-receipt-time-invalid",
+                "issued stage receipt had an invalid completion timestamp",
+                false,
+            )
+        })?;
+        let started = chrono::DateTime::parse_from_rfc3339(&started_at).expect("own RFC3339 time");
+        if started < prior {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-attestation-chronology-invalid",
+                "attestation began before its issued stage receipt completed",
+                false,
+            ));
+        }
+    }
     let started_monotonic = Instant::now();
     let task_sha256 = sha256(request.task.as_bytes());
     let mut transcript = Transcript::default();
@@ -260,6 +364,9 @@ async fn run_inner(
         ));
     }
     let initial_frame_sha256 = image_sha256(&initial.screenshot)?;
+    if request.mode == BoundedCuTaskMode::Attest {
+        request.observation_sha256 = Some(initial_frame_sha256.clone());
+    }
     transcript.push(
         0,
         "initial_frame",
@@ -367,6 +474,24 @@ async fn apply_cu_calls(
 ) -> Result<(), BoundedCuTaskError> {
     let mut call_ids = HashSet::with_capacity(response.cu_calls.len());
     let response_action_count = response.cu_calls.iter().try_fold(0_u64, |count, call| {
+        if !call.metadata.pending_safety_checks.is_empty() {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-pending-safety-check-refused",
+                "provider returned a pending computer-use safety check; no action was executed",
+                false,
+            ));
+        }
+        if call
+            .actions
+            .iter()
+            .any(|action| matches!(action, CuAction::Paste { .. }))
+        {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-paste-refused",
+                "clipboard paste is not permitted in the bounded proof lane; use typed input",
+                false,
+            ));
+        }
         if call.call_id.trim().is_empty()
             || call.call_id.len() > MAX_BINDING_BYTES
             || !call_ids.insert(call.call_id.as_str())
@@ -600,7 +725,8 @@ pub(crate) fn validate_bounded_cu_task_request(
             if request.prior_receipt_id.is_some()
                 || request.prior_transcript_event_count.is_some()
                 || request.prior_transcript_sha256.is_some()
-                || request.observation_sha256.is_some() =>
+                || request.observation_sha256.is_some()
+                || request.prior_completed_at.is_some() =>
         {
             Err(BoundedCuTaskError::new(
                 "bounded-cu-stage-lineage-invalid",
@@ -614,24 +740,19 @@ pub(crate) fn validate_bounded_cu_task_request(
 }
 
 fn validate_attestation_lineage(request: &BoundedCuTaskRequest) -> Result<(), BoundedCuTaskError> {
-    let prior_receipt = request
+    let prior_receipt_id = request
         .prior_receipt_id
         .as_deref()
         .filter(|value| is_receipt_id(value));
-    let prior_count = request
-        .prior_transcript_event_count
-        .filter(|count| *count > 0);
-    if prior_receipt.is_none()
-        || prior_count.is_none()
-        || !request
-            .prior_transcript_sha256
-            .as_deref()
-            .is_some_and(is_sha256)
-        || !request.observation_sha256.as_deref().is_some_and(is_sha256)
+    if prior_receipt_id.is_none()
+        || request.prior_transcript_event_count.is_some()
+        || request.prior_transcript_sha256.is_some()
+        || request.observation_sha256.is_some()
+        || request.prior_completed_at.is_some()
     {
         return Err(BoundedCuTaskError::new(
             "bounded-cu-attestation-lineage-invalid",
-            "attest mode requires the exact prior receipt, transcript, and observation digest",
+            "attest mode accepts only an issued stage receipt ID; transcript and frame lineage are derived by the daemon",
             false,
         ));
     }
@@ -1005,19 +1126,25 @@ mod tests {
             prior_transcript_event_count: None,
             prior_transcript_sha256: None,
             observation_sha256: None,
+            prior_completed_at: None,
         }
     }
 
-    fn attest_request() -> BoundedCuTaskRequest {
+    fn attest_request(prior_receipt_id: String) -> BoundedCuTaskRequest {
         BoundedCuTaskRequest {
             mode: BoundedCuTaskMode::Attest,
-            prior_receipt_id: Some(format!("bcu-{}", "c".repeat(64))),
-            prior_transcript_event_count: Some(4),
-            prior_transcript_sha256: Some("a".repeat(64)),
-            observation_sha256: Some("b".repeat(64)),
+            prior_receipt_id: Some(prior_receipt_id),
             task: "Inspect only and return {\"ready\":true}.".to_string(),
             ..stage_request()
         }
+    }
+
+    async fn issue_stage_receipt() -> BoundedCuTaskReceipt {
+        let provider = FakeProvider::new(vec![response(r#"{"ready":true}"#)]);
+        let mut executor = FakeExecutor::default();
+        run_bounded_cu_task(&provider, &mut executor, stage_request())
+            .await
+            .unwrap()
     }
 
     #[tokio::test]
@@ -1057,6 +1184,7 @@ mod tests {
 
     #[tokio::test]
     async fn attest_rejects_native_action_before_execution() {
+        let stage = issue_stage_receipt().await;
         let mut action_response = response("");
         action_response.cu_calls.push(CuToolCall {
             call_id: "cu-1".to_string(),
@@ -1065,12 +1193,43 @@ mod tests {
         });
         let provider = FakeProvider::new(vec![action_response]);
         let mut executor = FakeExecutor::default();
-        let error = run_bounded_cu_task(&provider, &mut executor, attest_request())
+        let error = run_bounded_cu_task(&provider, &mut executor, attest_request(stage.receipt_id))
             .await
             .unwrap_err();
 
         assert_eq!(error.code, "bounded-cu-post-observation-action-refused");
         assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
+    #[tokio::test]
+    async fn attest_derives_lineage_and_observation_from_issued_stage_and_frame() {
+        let stage = issue_stage_receipt().await;
+        let provider = FakeProvider::new(vec![response(r#"{"ready":true}"#)]);
+        let mut executor = FakeExecutor::default();
+        let receipt = run_bounded_cu_task(
+            &provider,
+            &mut executor,
+            attest_request(stage.receipt_id.clone()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            receipt.prior_receipt_id.as_deref(),
+            Some(stage.receipt_id.as_str())
+        );
+        assert_eq!(
+            receipt.prior_transcript_event_count,
+            Some(stage.transcript_event_count)
+        );
+        assert_eq!(
+            receipt.prior_transcript_sha256.as_deref(),
+            Some(stage.transcript_sha256.as_str())
+        );
+        assert_eq!(
+            receipt.observation_sha256.as_deref(),
+            Some(receipt.initial_frame_sha256.as_str())
+        );
     }
 
     #[tokio::test]
@@ -1112,17 +1271,61 @@ mod tests {
         assert_eq!(executor.batches, vec![vec!["screenshot"]]);
     }
 
+    #[tokio::test]
+    async fn pending_safety_checks_are_rejected_before_any_input() {
+        let mut action_response = response("");
+        action_response.cu_calls.push(CuToolCall {
+            call_id: "cu-safety".to_string(),
+            actions: vec![CuAction::Click {
+                x: 10,
+                y: 20,
+                button: MouseButton::Left,
+            }],
+            metadata: CuCallMetadata {
+                pending_safety_checks: vec![serde_json::json!({"id": "check-1"})],
+                safety_decision: None,
+            },
+        });
+        let provider = FakeProvider::new(vec![action_response]);
+        let mut executor = FakeExecutor::default();
+        let error = run_bounded_cu_task(&provider, &mut executor, stage_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "bounded-cu-pending-safety-check-refused");
+        assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
+    #[tokio::test]
+    async fn paste_is_rejected_before_clipboard_mutation() {
+        let mut action_response = response("");
+        action_response.cu_calls.push(CuToolCall {
+            call_id: "cu-paste".to_string(),
+            actions: vec![CuAction::Paste {
+                text: "secret".to_string(),
+            }],
+            metadata: CuCallMetadata::default(),
+        });
+        let provider = FakeProvider::new(vec![action_response]);
+        let mut executor = FakeExecutor::default();
+        let error = run_bounded_cu_task(&provider, &mut executor, stage_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "bounded-cu-paste-refused");
+        assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
     #[test]
     fn stage_and_attest_lineage_are_mutually_exclusive() {
         let mut stage = stage_request();
-        stage.observation_sha256 = Some("a".repeat(64));
+        stage.prior_receipt_id = Some(format!("bcu-{}", "a".repeat(64)));
         assert_eq!(
             validate_bounded_cu_task_request(&stage).unwrap_err().code,
             "bounded-cu-stage-lineage-invalid"
         );
 
-        let mut attest = attest_request();
-        attest.prior_transcript_sha256 = None;
+        let attest = attest_request("not-a-receipt".to_string());
         assert_eq!(
             validate_bounded_cu_task_request(&attest).unwrap_err().code,
             "bounded-cu-attestation-lineage-invalid"

--- a/src/bin/caller/bounded_cu_task.rs
+++ b/src/bin/caller/bounded_cu_task.rs
@@ -1,0 +1,1147 @@
+//! A small, fail-closed computer-use loop for externally orchestrated proof work.
+//!
+//! Unlike an Intendant agent session, this lane has no shell, filesystem,
+//! browser automation, delegation, escalation, or arbitrary function tools.
+//! It starts from one exact display screenshot, permits only native computer
+//! actions during `stage`, permits no action at all during `attest`, and returns
+//! a compact receipt whose transcript contains hashes and action kinds rather
+//! than potentially sensitive screen or typed text.
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use serde::de::{self, DeserializeSeed as _, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+
+use crate::computer_use::{CuAction, CuActionStatus};
+use crate::conversation::{Conversation, ImageData, MessageProvenance, ToolCallRef};
+use crate::provider::{ChatProvider, ChatResponse};
+
+pub(crate) const BOUNDED_CU_MAX_TASK_BYTES: usize = 16 * 1024;
+pub(crate) const BOUNDED_CU_MAX_RESULT_BYTES: usize = 16 * 1024;
+const BOUNDED_CU_MAX_BATCH_ACTIONS: usize = 16;
+const BOUNDED_CU_MAX_TOTAL_ACTIONS: u64 = 64;
+const BOUNDED_CU_MAX_ACTION_PAYLOAD_BYTES: usize = 64 * 1024;
+const BOUNDED_CU_STAGE_MAX_TURNS: u32 = 12;
+const BOUNDED_CU_ATTEST_MAX_TURNS: u32 = 2;
+const BOUNDED_CU_STAGE_TIMEOUT: Duration = Duration::from_secs(180);
+const BOUNDED_CU_ATTEST_TIMEOUT: Duration = Duration::from_secs(45);
+const MAX_BINDING_BYTES: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BoundedCuTaskMode {
+    Stage,
+    Attest,
+}
+
+impl BoundedCuTaskMode {
+    fn max_turns(self) -> u32 {
+        match self {
+            Self::Stage => BOUNDED_CU_STAGE_MAX_TURNS,
+            Self::Attest => BOUNDED_CU_ATTEST_MAX_TURNS,
+        }
+    }
+
+    fn timeout(self) -> Duration {
+        match self {
+            Self::Stage => BOUNDED_CU_STAGE_TIMEOUT,
+            Self::Attest => BOUNDED_CU_ATTEST_TIMEOUT,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stage => "stage",
+            Self::Attest => "attest",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedCuTaskRequest {
+    pub(crate) mode: BoundedCuTaskMode,
+    pub(crate) attempt_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) display_id: u32,
+    pub(crate) display_target: String,
+    pub(crate) capture_generation: String,
+    pub(crate) task: String,
+    pub(crate) prior_receipt_id: Option<String>,
+    pub(crate) prior_transcript_event_count: Option<u64>,
+    pub(crate) prior_transcript_sha256: Option<String>,
+    pub(crate) observation_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BoundedCuTaskReceipt {
+    pub(crate) schema_version: u32,
+    pub(crate) receipt_id: String,
+    pub(crate) mode: BoundedCuTaskMode,
+    pub(crate) attempt_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) display_id: u32,
+    pub(crate) display_target: String,
+    pub(crate) capture_generation: String,
+    pub(crate) provider: String,
+    pub(crate) model: String,
+    pub(crate) started_at: String,
+    pub(crate) completed_at: String,
+    pub(crate) elapsed_ms: u64,
+    pub(crate) turns: u32,
+    pub(crate) cu_batch_count: u64,
+    pub(crate) action_count: u64,
+    pub(crate) input_event_count: u64,
+    pub(crate) post_observation_input_event_count: u64,
+    pub(crate) forbidden_tool_call_count: u64,
+    pub(crate) escalation_count: u64,
+    pub(crate) initial_frame_sha256: String,
+    pub(crate) prior_receipt_id: Option<String>,
+    pub(crate) prior_transcript_event_count: Option<u64>,
+    pub(crate) prior_transcript_sha256: Option<String>,
+    pub(crate) observation_sha256: Option<String>,
+    pub(crate) current_transcript_event_count: u64,
+    pub(crate) transcript_event_count: u64,
+    pub(crate) transcript_sha256: String,
+    pub(crate) task_sha256: String,
+    pub(crate) result_sha256: String,
+    pub(crate) result: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedCuTaskError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+    pub(crate) retryable: bool,
+}
+
+impl BoundedCuTaskError {
+    pub(crate) fn new(code: &'static str, message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            retryable,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BoundedCuActionOutcome {
+    pub(crate) model_summary: String,
+    pub(crate) screenshot: ImageData,
+    pub(crate) statuses: Vec<CuActionStatus>,
+}
+
+#[async_trait]
+pub(crate) trait BoundedCuActionExecutor: Send {
+    async fn execute(
+        &mut self,
+        actions: &[CuAction],
+    ) -> Result<BoundedCuActionOutcome, BoundedCuTaskError>;
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TranscriptEvent {
+    sequence: u64,
+    turn: u32,
+    kind: &'static str,
+    detail: String,
+}
+
+#[derive(Default)]
+struct Transcript {
+    events: Vec<TranscriptEvent>,
+}
+
+impl Transcript {
+    fn push(&mut self, turn: u32, kind: &'static str, detail: String) {
+        self.events.push(TranscriptEvent {
+            sequence: self.events.len() as u64 + 1,
+            turn,
+            kind,
+            detail,
+        });
+    }
+
+    fn digest(&self, request: &BoundedCuTaskRequest) -> Result<String, BoundedCuTaskError> {
+        let bytes = serde_json::to_vec(&self.events).map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-transcript-serialization-failed",
+                error.to_string(),
+                false,
+            )
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(b"intendant-bounded-cu-transcript-v1\0");
+        if let Some(prior) = &request.prior_transcript_sha256 {
+            hasher.update(prior.as_bytes());
+        }
+        hasher.update(b"\0");
+        hasher.update(&bytes);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+}
+
+struct TaskCounters {
+    turns: u32,
+    cu_batches: u64,
+    actions: u64,
+    inputs: u64,
+}
+
+impl TaskCounters {
+    fn new() -> Self {
+        Self {
+            turns: 0,
+            cu_batches: 0,
+            actions: 0,
+            inputs: 0,
+        }
+    }
+}
+
+/// Run one strictly bounded CU-only task.
+pub(crate) async fn run_bounded_cu_task(
+    provider: &dyn ChatProvider,
+    executor: &mut dyn BoundedCuActionExecutor,
+    request: BoundedCuTaskRequest,
+) -> Result<BoundedCuTaskReceipt, BoundedCuTaskError> {
+    validate_bounded_cu_task_request(&request)?;
+    let timeout = request.mode.timeout();
+    match tokio::time::timeout(timeout, run_inner(provider, executor, request)).await {
+        Ok(result) => result,
+        Err(_) => Err(BoundedCuTaskError::new(
+            "bounded-cu-deadline-exceeded",
+            format!(
+                "bounded CU task exceeded its fixed {}s deadline",
+                timeout.as_secs()
+            ),
+            true,
+        )),
+    }
+}
+
+async fn run_inner(
+    provider: &dyn ChatProvider,
+    executor: &mut dyn BoundedCuActionExecutor,
+    request: BoundedCuTaskRequest,
+) -> Result<BoundedCuTaskReceipt, BoundedCuTaskError> {
+    if !provider.cu_enabled() {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-provider-not-capable",
+            "selected provider does not expose native computer use",
+            false,
+        ));
+    }
+    let started_at = now_rfc3339();
+    let started_monotonic = Instant::now();
+    let task_sha256 = sha256(request.task.as_bytes());
+    let mut transcript = Transcript::default();
+    transcript.push(
+        0,
+        "request",
+        format!(
+            "mode={};task_sha256={task_sha256};display_id={}",
+            request.mode.as_str(),
+            request.display_id
+        ),
+    );
+
+    let initial = executor.execute(&[CuAction::Screenshot]).await?;
+    if initial.statuses.as_slice() != [CuActionStatus::Verified] {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-initial-frame-failed",
+            "the exact bound display could not produce a verified initial frame",
+            false,
+        ));
+    }
+    let initial_frame_sha256 = image_sha256(&initial.screenshot)?;
+    transcript.push(
+        0,
+        "initial_frame",
+        format!(
+            "sha256={initial_frame_sha256};statuses={}",
+            status_labels(&initial.statuses)
+        ),
+    );
+    let system_prompt = bounded_system_prompt(request.mode);
+    let mut conversation = Conversation::new(system_prompt, provider.context_window());
+    conversation.add_user_with_images(
+        MessageProvenance::Task,
+        request.task.clone(),
+        vec![initial.screenshot],
+    );
+
+    let mut counters = TaskCounters::new();
+    let max_turns = request.mode.max_turns();
+    for turn in 1..=max_turns {
+        counters.turns = turn;
+        if provider.requires_image_stripping() {
+            conversation.strip_old_images();
+        }
+        let response = provider
+            .chat(conversation.messages())
+            .await
+            .map_err(|error| {
+                BoundedCuTaskError::new("bounded-cu-provider-failed", error.to_string(), true)
+            })?;
+        record_response(&mut transcript, turn, &response);
+        if !response.tool_calls.is_empty() {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-forbidden-tool-call",
+                format!(
+                    "provider returned {} function tool call(s) in a CU-only lane",
+                    response.tool_calls.len()
+                ),
+                false,
+            ));
+        }
+        if !response.cu_calls.is_empty() {
+            if request.mode == BoundedCuTaskMode::Attest {
+                return Err(BoundedCuTaskError::new(
+                    "bounded-cu-post-observation-action-refused",
+                    "attestation mode returned a native computer action; none was executed",
+                    false,
+                ));
+            }
+            apply_cu_calls(
+                executor,
+                &mut conversation,
+                &mut transcript,
+                &mut counters,
+                turn,
+                response,
+            )
+            .await?;
+            continue;
+        }
+
+        conversation.add_assistant(response.content.clone());
+        match parse_result(&response.content) {
+            Ok((result, result_sha256)) => {
+                transcript.push(turn, "result", format!("sha256={result_sha256}"));
+                return build_receipt(
+                    provider,
+                    request,
+                    ReceiptCompletion {
+                        started_at,
+                        elapsed_ms: u64::try_from(started_monotonic.elapsed().as_millis())
+                            .unwrap_or(u64::MAX),
+                        counters,
+                        transcript,
+                        initial_frame_sha256,
+                        result,
+                        result_sha256,
+                    },
+                );
+            }
+            Err(error) if turn < max_turns => {
+                transcript.push(turn, "invalid_result", format!("code={}", error.code));
+                conversation.add_user(
+                    MessageProvenance::SystemInjection,
+                    "Your last response was not one bounded JSON object. Inspect the current frame only as allowed, then return the requested JSON object with no prose or Markdown."
+                        .to_string(),
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(BoundedCuTaskError::new(
+        "bounded-cu-turn-limit-exceeded",
+        "bounded CU task exhausted its fixed turn limit",
+        false,
+    ))
+}
+
+async fn apply_cu_calls(
+    executor: &mut dyn BoundedCuActionExecutor,
+    conversation: &mut Conversation,
+    transcript: &mut Transcript,
+    counters: &mut TaskCounters,
+    turn: u32,
+    response: ChatResponse,
+) -> Result<(), BoundedCuTaskError> {
+    let mut call_ids = HashSet::with_capacity(response.cu_calls.len());
+    let response_action_count = response.cu_calls.iter().try_fold(0_u64, |count, call| {
+        if call.call_id.trim().is_empty()
+            || call.call_id.len() > MAX_BINDING_BYTES
+            || !call_ids.insert(call.call_id.as_str())
+        {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-call-id-invalid",
+                "native computer call IDs must be nonempty, bounded, and unique per response",
+                false,
+            ));
+        }
+        if call.actions.is_empty() || call.actions.len() > BOUNDED_CU_MAX_BATCH_ACTIONS {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-action-batch-invalid",
+                "native computer action batch was empty or exceeded the fixed batch cap",
+                false,
+            ));
+        }
+        let payload_bytes = serde_json::to_vec(&call.actions).map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-action-serialization-failed",
+                error.to_string(),
+                false,
+            )
+        })?;
+        if payload_bytes.len() > BOUNDED_CU_MAX_ACTION_PAYLOAD_BYTES {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-action-payload-too-large",
+                "native computer action payload exceeded the fixed byte cap",
+                false,
+            ));
+        }
+        count.checked_add(call.actions.len() as u64).ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-action-count-overflow",
+                "native computer action count overflowed",
+                false,
+            )
+        })
+    })?;
+    if counters.actions.saturating_add(response_action_count) > BOUNDED_CU_MAX_TOTAL_ACTIONS {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-action-limit-exceeded",
+            "native computer actions exceeded the fixed task cap",
+            false,
+        ));
+    }
+
+    let refs = response
+        .cu_calls
+        .iter()
+        .map(|call| ToolCallRef {
+            id: call.call_id.clone(),
+            call_id: call.call_id.clone(),
+            name: "computer".to_string(),
+            arguments: String::new(),
+        })
+        .collect();
+    conversation.add_assistant_tool_calls(response.content, refs, response.raw_output);
+    for call in response.cu_calls {
+        let action_kinds = call
+            .actions
+            .iter()
+            .map(action_kind)
+            .collect::<Vec<_>>()
+            .join(",");
+        let action_bytes = serde_json::to_vec(&call.actions).map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-action-serialization-failed",
+                error.to_string(),
+                false,
+            )
+        })?;
+        let actions_sha256 = sha256(&action_bytes);
+        let call_id_sha256 = sha256(call.call_id.as_bytes());
+        let input_count = call
+            .actions
+            .iter()
+            .filter(|action| is_input(action))
+            .count() as u64;
+        let outcome = executor.execute(&call.actions).await?;
+        let frame_sha256 = image_sha256(&outcome.screenshot)?;
+        if outcome.statuses.len() != call.actions.len() {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-action-cardinality-mismatch",
+                "native computer result count did not match the action count",
+                false,
+            ));
+        }
+        if outcome.statuses.contains(&CuActionStatus::Failed) {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-action-failed",
+                "at least one native computer action or its trailing observation failed",
+                false,
+            ));
+        }
+        counters.cu_batches += 1;
+        counters.actions += call.actions.len() as u64;
+        counters.inputs += input_count;
+        transcript.push(
+            turn,
+            "cu_batch",
+            format!(
+                "actions={action_kinds};actions_sha256={actions_sha256};call_id_sha256={call_id_sha256};frame_sha256={frame_sha256};statuses={};inputs={input_count}",
+                status_labels(&outcome.statuses)
+            ),
+        );
+        conversation.add_cu_result(
+            &call.call_id,
+            &outcome.model_summary,
+            vec![outcome.screenshot],
+        );
+    }
+    Ok(())
+}
+
+struct ReceiptCompletion {
+    started_at: String,
+    elapsed_ms: u64,
+    counters: TaskCounters,
+    transcript: Transcript,
+    initial_frame_sha256: String,
+    result: serde_json::Value,
+    result_sha256: String,
+}
+
+fn build_receipt(
+    provider: &dyn ChatProvider,
+    request: BoundedCuTaskRequest,
+    completion: ReceiptCompletion,
+) -> Result<BoundedCuTaskReceipt, BoundedCuTaskError> {
+    let ReceiptCompletion {
+        started_at,
+        elapsed_ms,
+        counters,
+        transcript,
+        initial_frame_sha256,
+        result,
+        result_sha256,
+    } = completion;
+    let completed_at = now_rfc3339();
+    if completed_at < started_at {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-clock-regressed",
+            "wall clock moved backwards during the bounded CU task",
+            false,
+        ));
+    }
+    let current_transcript_event_count = transcript.events.len() as u64;
+    let transcript_event_count = request
+        .prior_transcript_event_count
+        .unwrap_or(0)
+        .checked_add(current_transcript_event_count)
+        .ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-transcript-count-overflow",
+                "transcript event count overflowed",
+                false,
+            )
+        })?;
+    let transcript_sha256 = transcript.digest(&request)?;
+    let task_sha256 = sha256(request.task.as_bytes());
+    let mut receipt = BoundedCuTaskReceipt {
+        schema_version: 1,
+        receipt_id: String::new(),
+        mode: request.mode,
+        attempt_id: request.attempt_id,
+        workspace_id: request.workspace_id,
+        display_id: request.display_id,
+        display_target: request.display_target,
+        capture_generation: request.capture_generation,
+        provider: provider.name().to_string(),
+        model: provider.model().to_string(),
+        started_at,
+        completed_at,
+        elapsed_ms,
+        turns: counters.turns,
+        cu_batch_count: counters.cu_batches,
+        action_count: counters.actions,
+        input_event_count: counters.inputs,
+        post_observation_input_event_count: 0,
+        forbidden_tool_call_count: 0,
+        escalation_count: 0,
+        initial_frame_sha256,
+        prior_receipt_id: request.prior_receipt_id,
+        prior_transcript_event_count: request.prior_transcript_event_count,
+        prior_transcript_sha256: request.prior_transcript_sha256,
+        observation_sha256: request.observation_sha256,
+        current_transcript_event_count,
+        transcript_event_count,
+        transcript_sha256,
+        task_sha256,
+        result_sha256,
+        result,
+    };
+    receipt.receipt_id = receipt_id(&receipt)?;
+    Ok(receipt)
+}
+
+pub(crate) fn validate_bounded_cu_task_request(
+    request: &BoundedCuTaskRequest,
+) -> Result<(), BoundedCuTaskError> {
+    for (name, value) in [
+        ("attempt_id", request.attempt_id.as_str()),
+        ("workspace_id", request.workspace_id.as_str()),
+        ("capture_generation", request.capture_generation.as_str()),
+    ] {
+        if value.trim().is_empty() || value.len() > MAX_BINDING_BYTES {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-binding-invalid",
+                format!("{name} must be nonempty and at most {MAX_BINDING_BYTES} bytes"),
+                false,
+            ));
+        }
+    }
+    if request.display_target != format!("display_{}", request.display_id) {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-display-binding-invalid",
+            "display_target did not match display_id",
+            false,
+        ));
+    }
+    if request.task.trim().is_empty() || request.task.len() > BOUNDED_CU_MAX_TASK_BYTES {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-task-invalid",
+            format!("task must be nonempty and at most {BOUNDED_CU_MAX_TASK_BYTES} bytes"),
+            false,
+        ));
+    }
+    match request.mode {
+        BoundedCuTaskMode::Stage
+            if request.prior_receipt_id.is_some()
+                || request.prior_transcript_event_count.is_some()
+                || request.prior_transcript_sha256.is_some()
+                || request.observation_sha256.is_some() =>
+        {
+            Err(BoundedCuTaskError::new(
+                "bounded-cu-stage-lineage-invalid",
+                "stage mode cannot claim a prior receipt or observation",
+                false,
+            ))
+        }
+        BoundedCuTaskMode::Attest => validate_attestation_lineage(request),
+        BoundedCuTaskMode::Stage => Ok(()),
+    }
+}
+
+fn validate_attestation_lineage(request: &BoundedCuTaskRequest) -> Result<(), BoundedCuTaskError> {
+    let prior_receipt = request
+        .prior_receipt_id
+        .as_deref()
+        .filter(|value| is_receipt_id(value));
+    let prior_count = request
+        .prior_transcript_event_count
+        .filter(|count| *count > 0);
+    if prior_receipt.is_none()
+        || prior_count.is_none()
+        || !request
+            .prior_transcript_sha256
+            .as_deref()
+            .is_some_and(is_sha256)
+        || !request.observation_sha256.as_deref().is_some_and(is_sha256)
+    {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-attestation-lineage-invalid",
+            "attest mode requires the exact prior receipt, transcript, and observation digest",
+            false,
+        ));
+    }
+    Ok(())
+}
+
+fn bounded_system_prompt(mode: BoundedCuTaskMode) -> String {
+    match mode {
+        BoundedCuTaskMode::Stage => "You are a bounded computer-use operator on one isolated virtual display. Use only native computer actions to arrange the requested visual proof. You have no shell, filesystem, browser automation API, delegation, function tools, or escalation. Never navigate outside the requested task. When the proof is visibly ready, return exactly one JSON object matching the task's requested result shape, with no prose or Markdown."
+            .to_string(),
+        BoundedCuTaskMode::Attest => "You are a read-only visual attestor. Inspect the supplied current screenshot and return exactly one JSON object matching the task's requested result shape, with no prose or Markdown. Do not call any native computer action, including screenshot, wait, zoom, pointer, keyboard, or scroll. You have no shell, filesystem, browser automation API, delegation, function tools, or escalation."
+            .to_string(),
+    }
+}
+
+fn parse_result(raw: &str) -> Result<(serde_json::Value, String), BoundedCuTaskError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.len() > BOUNDED_CU_MAX_RESULT_BYTES {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-result-size-invalid",
+            format!("result must be nonempty and at most {BOUNDED_CU_MAX_RESULT_BYTES} bytes"),
+            false,
+        ));
+    }
+    let mut deserializer = serde_json::Deserializer::from_str(trimmed);
+    let value = UniqueJsonValueSeed
+        .deserialize(&mut deserializer)
+        .and_then(|value| {
+            deserializer.end()?;
+            Ok(value)
+        })
+        .map_err(|_| {
+            BoundedCuTaskError::new(
+                "bounded-cu-result-json-invalid",
+                "result was not one standalone duplicate-free JSON value",
+                false,
+            )
+        })?;
+    if !value.is_object() {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-result-shape-invalid",
+            "result must be one JSON object",
+            false,
+        ));
+    }
+    let canonical = serde_json::to_vec(&value).map_err(|error| {
+        BoundedCuTaskError::new(
+            "bounded-cu-result-serialization-failed",
+            error.to_string(),
+            false,
+        )
+    })?;
+    Ok((value, sha256(&canonical)))
+}
+
+struct UniqueJsonValueSeed;
+
+impl<'de> de::DeserializeSeed<'de> for UniqueJsonValueSeed {
+    type Value = serde_json::Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UniqueJsonValueVisitor)
+    }
+}
+
+struct UniqueJsonValueVisitor;
+
+impl<'de> Visitor<'de> for UniqueJsonValueVisitor {
+    type Value = serde_json::Value;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a duplicate-free JSON value")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| E::custom("non-finite JSON number"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::String(value.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element_seed(UniqueJsonValueSeed)? {
+            values.push(value);
+        }
+        Ok(serde_json::Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = serde_json::Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(de::Error::custom(format!("duplicate JSON key: {key}")));
+            }
+            let value = map.next_value_seed(UniqueJsonValueSeed)?;
+            values.insert(key, value);
+        }
+        Ok(serde_json::Value::Object(values))
+    }
+}
+
+fn record_response(transcript: &mut Transcript, turn: u32, response: &ChatResponse) {
+    transcript.push(
+        turn,
+        "provider_response",
+        format!(
+            "content_sha256={};content_bytes={};cu_calls={};tool_calls={}",
+            sha256(response.content.as_bytes()),
+            response.content.len(),
+            response.cu_calls.len(),
+            response.tool_calls.len()
+        ),
+    );
+}
+
+fn receipt_id(receipt: &BoundedCuTaskReceipt) -> Result<String, BoundedCuTaskError> {
+    let mut projection = serde_json::to_value(receipt).map_err(|error| {
+        BoundedCuTaskError::new(
+            "bounded-cu-receipt-serialization-failed",
+            error.to_string(),
+            false,
+        )
+    })?;
+    projection
+        .as_object_mut()
+        .expect("bounded CU receipt serializes as an object")
+        .remove("receiptId");
+    let bytes = serde_json::to_vec(&projection).map_err(|error| {
+        BoundedCuTaskError::new(
+            "bounded-cu-receipt-serialization-failed",
+            error.to_string(),
+            false,
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"intendant-bounded-cu-receipt-v1\0");
+    hasher.update(bytes);
+    Ok(format!("bcu-{:x}", hasher.finalize()))
+}
+
+fn action_kind(action: &CuAction) -> &'static str {
+    match action {
+        CuAction::Click { .. } => "click",
+        CuAction::DoubleClick { .. } => "double_click",
+        CuAction::TripleClick { .. } => "triple_click",
+        CuAction::MouseDown { .. } => "mouse_down",
+        CuAction::MouseUp { .. } => "mouse_up",
+        CuAction::Type { .. } => "type",
+        CuAction::Paste { .. } => "paste",
+        CuAction::Key { .. } => "key",
+        CuAction::HoldKey { .. } => "hold_key",
+        CuAction::Scroll { .. } => "scroll",
+        CuAction::MoveMouse { .. } => "move_mouse",
+        CuAction::Drag { .. } => "drag",
+        CuAction::Screenshot => "screenshot",
+        CuAction::Zoom { .. } => "zoom",
+        CuAction::Wait { .. } => "wait",
+    }
+}
+
+fn is_input(action: &CuAction) -> bool {
+    !matches!(
+        action,
+        CuAction::Screenshot | CuAction::Zoom { .. } | CuAction::Wait { .. }
+    )
+}
+
+fn status_labels(statuses: &[CuActionStatus]) -> String {
+    statuses
+        .iter()
+        .map(|status| status.label())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn image_sha256(image: &ImageData) -> Result<String, BoundedCuTaskError> {
+    if image.media_type != "image/png" {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-frame-media-type-invalid",
+            "bounded CU frames must be PNG images",
+            false,
+        ));
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(&image.data)
+        .map_err(|_| {
+            BoundedCuTaskError::new(
+                "bounded-cu-frame-base64-invalid",
+                "bounded CU frame was not valid canonical base64",
+                false,
+            )
+        })?;
+    if !bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-frame-png-invalid",
+            "bounded CU frame did not begin with the PNG signature",
+            false,
+        ));
+    }
+    Ok(sha256(&bytes))
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn is_receipt_id(value: &str) -> bool {
+    value.strip_prefix("bcu-").is_some_and(is_sha256)
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::computer_use::{CuCallMetadata, CuToolCall, MouseButton};
+    use crate::error::CallerError;
+    use crate::provider::{TokenUsage, ToolCall};
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    struct FakeProvider {
+        responses: Mutex<VecDeque<ChatResponse>>,
+    }
+
+    impl FakeProvider {
+        fn new(responses: Vec<ChatResponse>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ChatProvider for FakeProvider {
+        async fn chat(
+            &self,
+            _messages: &[crate::conversation::Message],
+        ) -> Result<ChatResponse, CallerError> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| CallerError::Provider("no fake response".to_string()))
+        }
+
+        fn name(&self) -> &str {
+            "fake"
+        }
+
+        fn model(&self) -> &str {
+            "fake-cu"
+        }
+
+        fn context_window(&self) -> u64 {
+            16_384
+        }
+
+        fn max_output_tokens(&self) -> u64 {
+            1_024
+        }
+
+        fn cu_enabled(&self) -> bool {
+            true
+        }
+
+        fn requires_image_stripping(&self) -> bool {
+            false
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeExecutor {
+        batches: Vec<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl BoundedCuActionExecutor for FakeExecutor {
+        async fn execute(
+            &mut self,
+            actions: &[CuAction],
+        ) -> Result<BoundedCuActionOutcome, BoundedCuTaskError> {
+            self.batches.push(
+                actions
+                    .iter()
+                    .map(|action| action_kind(action).to_string())
+                    .collect(),
+            );
+            Ok(BoundedCuActionOutcome {
+                model_summary: "Actions executed successfully.".to_string(),
+                screenshot: ImageData {
+                    media_type: "image/png".to_string(),
+                    data: "iVBORw0KGgo=".to_string(),
+                },
+                statuses: vec![CuActionStatus::Verified; actions.len()],
+            })
+        }
+    }
+
+    fn response(content: &str) -> ChatResponse {
+        ChatResponse {
+            content: content.to_string(),
+            usage: TokenUsage::default(),
+            reasoning_summary: None,
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            cu_calls: Vec::new(),
+            raw_output: None,
+        }
+    }
+
+    fn stage_request() -> BoundedCuTaskRequest {
+        BoundedCuTaskRequest {
+            mode: BoundedCuTaskMode::Stage,
+            attempt_id: "attempt-1".to_string(),
+            workspace_id: "bw-1".to_string(),
+            display_id: 99,
+            display_target: "display_99".to_string(),
+            capture_generation: "vdcg-1".to_string(),
+            task: "Prepare proof and return {\"ready\":true}.".to_string(),
+            prior_receipt_id: None,
+            prior_transcript_event_count: None,
+            prior_transcript_sha256: None,
+            observation_sha256: None,
+        }
+    }
+
+    fn attest_request() -> BoundedCuTaskRequest {
+        BoundedCuTaskRequest {
+            mode: BoundedCuTaskMode::Attest,
+            prior_receipt_id: Some(format!("bcu-{}", "c".repeat(64))),
+            prior_transcript_event_count: Some(4),
+            prior_transcript_sha256: Some("a".repeat(64)),
+            observation_sha256: Some("b".repeat(64)),
+            task: "Inspect only and return {\"ready\":true}.".to_string(),
+            ..stage_request()
+        }
+    }
+
+    #[tokio::test]
+    async fn stage_executes_only_native_actions_and_returns_bound_receipt() {
+        let mut action_response = response("");
+        action_response.cu_calls.push(CuToolCall {
+            call_id: "cu-1".to_string(),
+            actions: vec![CuAction::Click {
+                x: 10,
+                y: 20,
+                button: MouseButton::Left,
+            }],
+            metadata: CuCallMetadata::default(),
+        });
+        let provider = FakeProvider::new(vec![action_response, response(r#"{"ready":true}"#)]);
+        let mut executor = FakeExecutor::default();
+        let receipt = run_bounded_cu_task(&provider, &mut executor, stage_request())
+            .await
+            .unwrap();
+
+        assert_eq!(executor.batches, vec![vec!["screenshot"], vec!["click"]]);
+        assert_eq!(receipt.action_count, 1);
+        assert_eq!(receipt.input_event_count, 1);
+        assert_eq!(receipt.post_observation_input_event_count, 0);
+        assert_eq!(receipt.forbidden_tool_call_count, 0);
+        assert_eq!(receipt.escalation_count, 0);
+        assert_eq!(receipt.result["ready"], true);
+        assert!(receipt.transcript_event_count >= 5);
+        assert!(is_sha256(&receipt.transcript_sha256));
+        assert!(is_receipt_id(&receipt.receipt_id));
+        assert_eq!(receipt_id(&receipt).unwrap(), receipt.receipt_id);
+
+        let mut altered = receipt.clone();
+        altered.input_event_count += 1;
+        assert_ne!(receipt_id(&altered).unwrap(), receipt.receipt_id);
+    }
+
+    #[tokio::test]
+    async fn attest_rejects_native_action_before_execution() {
+        let mut action_response = response("");
+        action_response.cu_calls.push(CuToolCall {
+            call_id: "cu-1".to_string(),
+            actions: vec![CuAction::Screenshot],
+            metadata: CuCallMetadata::default(),
+        });
+        let provider = FakeProvider::new(vec![action_response]);
+        let mut executor = FakeExecutor::default();
+        let error = run_bounded_cu_task(&provider, &mut executor, attest_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "bounded-cu-post-observation-action-refused");
+        assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
+    #[tokio::test]
+    async fn function_tool_call_is_never_repaired_or_executed() {
+        let mut tool_response = response("");
+        tool_response.tool_calls.push(ToolCall {
+            id: "tool-1".to_string(),
+            call_id: "tool-1".to_string(),
+            name: "escalate_to_agent".to_string(),
+            arguments: r#"{"task":"escape"}"#.to_string(),
+        });
+        let provider = FakeProvider::new(vec![tool_response]);
+        let mut executor = FakeExecutor::default();
+        let error = run_bounded_cu_task(&provider, &mut executor, stage_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "bounded-cu-forbidden-tool-call");
+        assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
+    #[tokio::test]
+    async fn duplicate_cu_call_ids_are_rejected_before_any_input() {
+        let mut action_response = response("");
+        for _ in 0..2 {
+            action_response.cu_calls.push(CuToolCall {
+                call_id: "duplicate".to_string(),
+                actions: vec![CuAction::Screenshot],
+                metadata: CuCallMetadata::default(),
+            });
+        }
+        let provider = FakeProvider::new(vec![action_response]);
+        let mut executor = FakeExecutor::default();
+        let error = run_bounded_cu_task(&provider, &mut executor, stage_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "bounded-cu-call-id-invalid");
+        assert_eq!(executor.batches, vec![vec!["screenshot"]]);
+    }
+
+    #[test]
+    fn stage_and_attest_lineage_are_mutually_exclusive() {
+        let mut stage = stage_request();
+        stage.observation_sha256 = Some("a".repeat(64));
+        assert_eq!(
+            validate_bounded_cu_task_request(&stage).unwrap_err().code,
+            "bounded-cu-stage-lineage-invalid"
+        );
+
+        let mut attest = attest_request();
+        attest.prior_transcript_sha256 = None;
+        assert_eq!(
+            validate_bounded_cu_task_request(&attest).unwrap_err().code,
+            "bounded-cu-attestation-lineage-invalid"
+        );
+    }
+
+    #[test]
+    fn provider_result_rejects_duplicate_keys_at_every_depth() {
+        assert_eq!(
+            parse_result(r#"{"ready":true,"ready":false}"#)
+                .unwrap_err()
+                .code,
+            "bounded-cu-result-json-invalid"
+        );
+        assert_eq!(
+            parse_result(r#"{"proof":{"visible":true,"visible":false}}"#)
+                .unwrap_err()
+                .code,
+            "bounded-cu-result-json-invalid"
+        );
+    }
+}

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -741,6 +741,12 @@ pub async fn create_workspace(
     let bound_display_target = display_binding
         .as_ref()
         .map(|binding| binding.canonical.clone());
+    let _display_access = match bound_display_id {
+        Some(display_id) => {
+            Some(crate::computer_use::acquire_virtual_display_shared(display_id).await)
+        }
+        None => None,
+    };
     let profile_dir = request
         .profile_dir
         .as_deref()
@@ -969,6 +975,7 @@ pub async fn close_workspace(
     id: &str,
     reason: Option<String>,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
+    let _display_access = acquire_workspace_display_access(id).await?;
     let (mut workspace, child) = global_registry()
         .write()
         .await
@@ -986,6 +993,7 @@ pub async fn acquire_workspace(
     request: AcquireBrowserWorkspaceRequest,
     bus: &EventBus,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
+    let _display_access = acquire_workspace_display_access(&request.workspace_id).await?;
     let (result, retired) = {
         let registry = global_registry();
         let mut registry = registry.write().await;
@@ -1005,6 +1013,7 @@ pub async fn release_workspace(
     request: ReleaseBrowserWorkspaceRequest,
     bus: &EventBus,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
+    let _display_access = acquire_workspace_display_access(&request.workspace_id).await?;
     let (result, retired) = {
         let registry = global_registry();
         let mut registry = registry.write().await;
@@ -1018,6 +1027,24 @@ pub async fn release_workspace(
     };
     terminate_retired_processes(retired);
     result
+}
+
+async fn acquire_workspace_display_access(
+    workspace_id: &str,
+) -> Result<Option<tokio::sync::OwnedRwLockReadGuard<()>>, BrowserWorkspaceError> {
+    let display_target = global_registry()
+        .read()
+        .await
+        .workspaces
+        .get(workspace_id)
+        .and_then(|workspace| workspace.display_target.clone());
+    let Some(display_target) = display_target else {
+        return Ok(None);
+    };
+    let binding = parse_browser_display_binding(&display_target)?;
+    Ok(Some(
+        crate::computer_use::acquire_virtual_display_shared(binding.display_id).await,
+    ))
 }
 
 fn publish_retirements_locked(bus: &EventBus, retired: &[RetiredBrowserWorkspace]) {

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -16,6 +16,7 @@ pub type SharedBrowserWorkspaceRegistry = Arc<RwLock<BrowserWorkspaceRegistry>>;
 static GLOBAL_BROWSER_WORKSPACES: OnceLock<SharedBrowserWorkspaceRegistry> = OnceLock::new();
 
 const CDP_STARTUP_TIMEOUT: Duration = Duration::from_secs(8);
+const CDP_LIVENESS_TIMEOUT: Duration = Duration::from_secs(2);
 const BROWSER_EXECUTABLE_ENV: &str = "INTENDANT_BROWSER_WORKSPACE_EXECUTABLE";
 const LEGACY_BROWSER_EXECUTABLE_ENV: &str = "INTENDANT_BROWSER_EXECUTABLE";
 // macOS-only system-browser escape hatch; other platforms' discovery path never consults it.
@@ -911,6 +912,93 @@ pub async fn list_workspaces(bus: &EventBus) -> Vec<BrowserWorkspace> {
     };
     terminate_retired_processes(retired);
     workspaces
+}
+
+/// Prove that the exact local workspace record still names a live child and
+/// an extant page target. Stored `Ready` metadata alone is not liveness: a
+/// browser may exit or its selected tab may close between bounded proof
+/// actions. The registry/child check brackets the CDP probe so a concurrent
+/// close or replacement cannot be mistaken for the requested workspace.
+pub(crate) async fn verify_live_workspace(workspace: &BrowserWorkspace) -> Result<(), String> {
+    verify_registered_child(workspace).await?;
+
+    let pid = workspace
+        .process_id
+        .ok_or_else(|| "browser workspace has no process id".to_string())?;
+    let port = workspace
+        .debugging_port
+        .ok_or_else(|| "browser workspace has no debugging port".to_string())?;
+    let target_id = workspace
+        .active_target_id
+        .as_deref()
+        .ok_or_else(|| "browser workspace has no active target id".to_string())?;
+    let expected_http = format!("http://127.0.0.1:{port}");
+    if workspace.cdp_http_url.as_deref() != Some(expected_http.as_str()) {
+        return Err("browser workspace CDP URL is not its exact loopback port".to_string());
+    }
+    if !crate::platform::process_alive(pid) {
+        return Err("browser workspace process is no longer live".to_string());
+    }
+
+    let list_url = format!("{expected_http}/json/list");
+    let response = reqwest::Client::new()
+        .get(&list_url)
+        .timeout(CDP_LIVENESS_TIMEOUT)
+        .send()
+        .await
+        .map_err(|error| format!("browser workspace CDP liveness probe failed: {error}"))?
+        .error_for_status()
+        .map_err(|error| format!("browser workspace CDP liveness probe failed: {error}"))?;
+    let targets: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|error| format!("browser workspace CDP target list was invalid: {error}"))?;
+    let target = exact_page_target(&targets, target_id)
+        .ok_or_else(|| "browser workspace active page target is no longer live".to_string())?;
+    let target_ws = target
+        .get("webSocketDebuggerUrl")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "browser workspace active page target has no debugger URL".to_string())?;
+    if workspace.cdp_ws_url.as_deref() != Some(target_ws) {
+        return Err("browser workspace active page debugger URL changed".to_string());
+    }
+
+    verify_registered_child(workspace).await?;
+    if !crate::platform::process_alive(pid) {
+        return Err("browser workspace process exited during its CDP liveness probe".to_string());
+    }
+    Ok(())
+}
+
+async fn verify_registered_child(workspace: &BrowserWorkspace) -> Result<(), String> {
+    let registry = global_registry();
+    let mut registry = registry.write().await;
+    let current = registry
+        .workspaces
+        .get(&workspace.id)
+        .ok_or_else(|| "browser workspace disappeared from the live registry".to_string())?;
+    if current != workspace {
+        return Err("browser workspace binding changed during the bounded proof task".to_string());
+    }
+    let child = registry
+        .children
+        .get_mut(&workspace.id)
+        .ok_or_else(|| "browser workspace has no daemon-owned child process".to_string())?;
+    match child.try_wait() {
+        Ok(None) => Ok(()),
+        Ok(Some(status)) => Err(format!("browser workspace child exited with {status}")),
+        Err(error) => Err(format!("cannot inspect browser workspace child: {error}")),
+    }
+}
+
+fn exact_page_target<'a>(
+    targets: &'a serde_json::Value,
+    target_id: &str,
+) -> Option<&'a serde_json::Value> {
+    targets.as_array()?.iter().find(|target| {
+        target.get("type").and_then(serde_json::Value::as_str) == Some("page")
+            && target.get("id").and_then(serde_json::Value::as_str) == Some(target_id)
+    })
 }
 
 pub async fn close_display_binding(
@@ -2077,6 +2165,23 @@ mod tests {
         let (ws, id) = first_page_target(&targets).unwrap();
         assert_eq!(id.as_deref(), Some("page-1"));
         assert_eq!(ws.as_deref(), Some("ws://127.0.0.1/devtools/page/page-1"));
+    }
+
+    #[test]
+    fn cdp_liveness_parser_requires_the_exact_page_target() {
+        let targets = serde_json::json!([
+            {"type":"page","id":"replacement","webSocketDebuggerUrl":"ws://127.0.0.1/devtools/page/replacement"},
+            {"type":"service_worker","id":"page-1","webSocketDebuggerUrl":"ws://127.0.0.1/devtools/worker/page-1"},
+            {"type":"page","id":"page-1","webSocketDebuggerUrl":"ws://127.0.0.1/devtools/page/page-1"}
+        ]);
+        let target = exact_page_target(&targets, "page-1").unwrap();
+        assert_eq!(
+            target
+                .get("webSocketDebuggerUrl")
+                .and_then(serde_json::Value::as_str),
+            Some("ws://127.0.0.1/devtools/page/page-1")
+        );
+        assert!(exact_page_target(&targets, "closed-page").is_none());
     }
 
     #[test]

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -35,9 +35,14 @@ pub(crate) async fn acquire_virtual_display_shared(
     virtual_display_gate(display_id).read_owned().await
 }
 
+#[derive(Clone)]
 pub(crate) struct VirtualDisplayExclusiveAccess {
     display_id: u32,
-    _guard: tokio::sync::OwnedRwLockWriteGuard<()>,
+    // The bounded lane may have to detach a non-abortable platform input
+    // operation when its request deadline expires. Every detached operation
+    // keeps a clone so ordinary input cannot resume until the OS work has
+    // actually stopped.
+    _guard: std::sync::Arc<tokio::sync::OwnedRwLockWriteGuard<()>>,
 }
 
 pub(crate) async fn acquire_virtual_display_exclusive(
@@ -45,7 +50,7 @@ pub(crate) async fn acquire_virtual_display_exclusive(
 ) -> VirtualDisplayExclusiveAccess {
     VirtualDisplayExclusiveAccess {
         display_id,
-        _guard: virtual_display_gate(display_id).write_owned().await,
+        _guard: std::sync::Arc::new(virtual_display_gate(display_id).write_owned().await),
     }
 }
 

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -3905,6 +3905,46 @@ fn mouse_button_index(button: MouseButton) -> u8 {
     }
 }
 
+/// Releases that make one bounded action cancellation-safe. The caller
+/// records these before dispatch and clears them only after the action and
+/// its trailing observation complete. Split mouse-edge actions are rejected
+/// by the bounded lane, but remain covered here as a defensive fallback.
+pub(crate) fn bounded_action_safety_releases(
+    action: &CuAction,
+    resolution: (u32, u32),
+) -> Result<Vec<crate::display::InputEvent>, String> {
+    let mouse_up = |x: i32, y: i32, button: MouseButton| {
+        let width = f64::from(resolution.0.max(1));
+        let height = f64::from(resolution.1.max(1));
+        crate::display::InputEvent::MouseUp {
+            x: (f64::from(x) / width).clamp(0.0, 1.0),
+            y: (f64::from(y) / height).clamp(0.0, 1.0),
+            b: mouse_button_index(button),
+        }
+    };
+    match action {
+        CuAction::Click { x, y, button }
+        | CuAction::DoubleClick { x, y, button }
+        | CuAction::TripleClick { x, y, button }
+        | CuAction::MouseDown { x, y, button }
+        | CuAction::MouseUp { x, y, button } => Ok(vec![mouse_up(*x, *y, *button)]),
+        CuAction::Drag { end_x, end_y, .. } => {
+            Ok(vec![mouse_up(*end_x, *end_y, MouseButton::Left)])
+        }
+        CuAction::Key { key } | CuAction::HoldKey { key, .. } => Ok(key_action_events(key)?
+            .into_iter()
+            .filter(|event| matches!(event, crate::display::InputEvent::KeyUp { .. }))
+            .collect()),
+        CuAction::Type { .. }
+        | CuAction::Paste { .. }
+        | CuAction::Scroll { .. }
+        | CuAction::MoveMouse { .. }
+        | CuAction::Screenshot
+        | CuAction::Zoom { .. }
+        | CuAction::Wait { .. } => Ok(Vec::new()),
+    }
+}
+
 /// Map a character to a DOM `KeyboardEvent.code` value.
 fn char_to_dom_code(ch: char) -> &'static str {
     match ch.to_ascii_lowercase() {
@@ -5295,6 +5335,37 @@ mod tests {
         assert_eq!(mouse_button_index(MouseButton::Left), 0);
         assert_eq!(mouse_button_index(MouseButton::Middle), 1);
         assert_eq!(mouse_button_index(MouseButton::Right), 2);
+    }
+
+    #[test]
+    fn bounded_safety_plan_releases_mouse_and_every_key_edge() {
+        let mouse = bounded_action_safety_releases(
+            &CuAction::Click {
+                x: 100,
+                y: 50,
+                button: MouseButton::Right,
+            },
+            (200, 100),
+        )
+        .unwrap();
+        assert!(matches!(
+            mouse.as_slice(),
+            [crate::display::InputEvent::MouseUp { x, y, b: 2 }]
+                if (*x - 0.5).abs() < f64::EPSILON && (*y - 0.5).abs() < f64::EPSILON
+        ));
+
+        let keys = bounded_action_safety_releases(
+            &CuAction::HoldKey {
+                key: "CTRL+C".to_string(),
+                ms: 1,
+            },
+            (200, 100),
+        )
+        .unwrap();
+        assert_eq!(keys.len(), 2);
+        assert!(keys
+            .iter()
+            .all(|event| matches!(event, crate::display::InputEvent::KeyUp { .. })));
     }
 
     // ── Result statuses & read-back helpers ─────────────────────────────

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -8,6 +8,47 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
+/// Per-virtual-display action/lifecycle gates. Ordinary display operations
+/// take a shared guard; the bounded proof lane takes the exclusive guard for
+/// its whole task. This closes the check-then-inject race without serializing
+/// independent Xvfb displays.
+fn virtual_display_gate(display_id: u32) -> std::sync::Arc<tokio::sync::RwLock<()>> {
+    static GATES: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<u32, std::sync::Weak<tokio::sync::RwLock<()>>>>,
+    > = std::sync::OnceLock::new();
+    let mut gates = GATES
+        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    gates.retain(|_, gate| gate.strong_count() > 0);
+    if let Some(gate) = gates.get(&display_id).and_then(std::sync::Weak::upgrade) {
+        return gate;
+    }
+    let gate = std::sync::Arc::new(tokio::sync::RwLock::new(()));
+    gates.insert(display_id, std::sync::Arc::downgrade(&gate));
+    gate
+}
+
+pub(crate) async fn acquire_virtual_display_shared(
+    display_id: u32,
+) -> tokio::sync::OwnedRwLockReadGuard<()> {
+    virtual_display_gate(display_id).read_owned().await
+}
+
+pub(crate) struct VirtualDisplayExclusiveAccess {
+    display_id: u32,
+    _guard: tokio::sync::OwnedRwLockWriteGuard<()>,
+}
+
+pub(crate) async fn acquire_virtual_display_exclusive(
+    display_id: u32,
+) -> VirtualDisplayExclusiveAccess {
+    VirtualDisplayExclusiveAccess {
+        display_id,
+        _guard: virtual_display_gate(display_id).write_owned().await,
+    }
+}
+
 // ── Display backend ──────────────────────────────────────────────────────────
 
 /// Display backend for input simulation and screenshot capture.
@@ -1008,22 +1049,90 @@ pub async fn execute_actions(
     observer: Option<&CuActionObserver>,
     options: CuExecOptions,
 ) -> CuBatchOutcome {
+    let _display_access = match target {
+        DisplayTarget::Virtual { id } => Some(acquire_virtual_display_shared(id).await),
+        DisplayTarget::UserSession => None,
+    };
+    execute_actions_inner(
+        actions,
+        target,
+        backend,
+        screenshot_dir,
+        action_counter,
+        session_registry,
+        denorm_ref,
+        user_session_allowed,
+        observer,
+        options,
+    )
+    .await
+}
+
+/// Execute while the bounded proof lane holds exclusive access to the exact
+/// virtual display. The access token prevents the proof path from
+/// recursively taking the ordinary shared gate and binds this bypass to the
+/// same display id.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_actions_with_exclusive_access(
+    access: &VirtualDisplayExclusiveAccess,
+    actions: &[CuAction],
+    target: DisplayTarget,
+    backend: DisplayBackend,
+    screenshot_dir: &Path,
+    action_counter: &mut u64,
+    session_registry: &Option<crate::display::SharedSessionRegistry>,
+    denorm_ref: Option<(u32, u32)>,
+    user_session_allowed: bool,
+    observer: Option<&CuActionObserver>,
+    options: CuExecOptions,
+) -> CuBatchOutcome {
+    if target
+        != (DisplayTarget::Virtual {
+            id: access.display_id,
+        })
+    {
+        return failed_batch(
+            actions,
+            "exclusive virtual-display access token does not match the action target",
+            "exclusive virtual-display access token mismatch",
+        );
+    }
+    execute_actions_inner(
+        actions,
+        target,
+        backend,
+        screenshot_dir,
+        action_counter,
+        session_registry,
+        denorm_ref,
+        user_session_allowed,
+        observer,
+        options,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_actions_inner(
+    actions: &[CuAction],
+    target: DisplayTarget,
+    backend: DisplayBackend,
+    screenshot_dir: &Path,
+    action_counter: &mut u64,
+    session_registry: &Option<crate::display::SharedSessionRegistry>,
+    denorm_ref: Option<(u32, u32)>,
+    user_session_allowed: bool,
+    observer: Option<&CuActionObserver>,
+    options: CuExecOptions,
+) -> CuBatchOutcome {
     if target.is_user_session() && !user_session_allowed {
         // One result per action, like every other outcome of this function
         // (a screenshot-only batch still gets its one denial).
-        return CuBatchOutcome {
-            results: actions
-                .iter()
-                .map(|_| CuActionResult::failed(user_session_denied_message()))
-                .collect(),
-            observation: CuObservation {
-                kind: CuObservationKind::None,
-                reason: "user_session denied".to_string(),
-                ax_text: None,
-            },
-            settle: None,
-            metrics: CuBatchMetrics::default(),
-        };
+        return failed_batch(
+            actions,
+            user_session_denied_message(),
+            "user_session denied",
+        );
     }
 
     #[cfg(target_os = "linux")]
@@ -1178,6 +1287,27 @@ pub async fn execute_actions(
         outcome.metrics_line(),
     );
     outcome
+}
+
+fn failed_batch(
+    actions: &[CuAction],
+    message: impl Into<String>,
+    reason: impl Into<String>,
+) -> CuBatchOutcome {
+    let message = message.into();
+    CuBatchOutcome {
+        results: actions
+            .iter()
+            .map(|_| CuActionResult::failed(message.clone()))
+            .collect(),
+        observation: CuObservation {
+            kind: CuObservationKind::None,
+            reason: reason.into(),
+            ax_text: None,
+        },
+        settle: None,
+        metrics: CuBatchMetrics::default(),
+    }
 }
 
 fn target_uses_private_x11_session(target: DisplayTarget) -> bool {
@@ -4746,6 +4876,75 @@ mod tests {
         .results;
         let error = results[0].error.as_deref().unwrap_or_default();
         assert_ne!(error, user_session_denied_message());
+    }
+
+    #[tokio::test]
+    async fn execute_actions_waits_for_exclusive_virtual_display_access() {
+        let target = DisplayTarget::Virtual { id: 4322 };
+        let exclusive = acquire_virtual_display_exclusive(4322).await;
+        let dir = std::env::temp_dir();
+        let mut counter = 0_u64;
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            execute_actions(
+                &[CuAction::Screenshot],
+                target,
+                DisplayBackend::Windows,
+                &dir,
+                &mut counter,
+                &None,
+                None,
+                false,
+                None,
+                CuExecOptions::default(),
+            ),
+        )
+        .await
+        .is_err());
+        drop(exclusive);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            execute_actions(
+                &[CuAction::Screenshot],
+                target,
+                DisplayBackend::Windows,
+                &dir,
+                &mut counter,
+                &None,
+                None,
+                false,
+                None,
+                CuExecOptions::default(),
+            ),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn exclusive_virtual_display_access_is_target_bound() {
+        let exclusive = acquire_virtual_display_exclusive(4323).await;
+        let dir = std::env::temp_dir();
+        let mut counter = 0_u64;
+        let outcome = execute_actions_with_exclusive_access(
+            &exclusive,
+            &[CuAction::Screenshot],
+            DisplayTarget::Virtual { id: 4324 },
+            DisplayBackend::Windows,
+            &dir,
+            &mut counter,
+            &None,
+            None,
+            false,
+            None,
+            CuExecOptions::default(),
+        )
+        .await;
+        assert_eq!(outcome.results.len(), 1);
+        assert_eq!(
+            outcome.results[0].error.as_deref(),
+            Some("exclusive virtual-display access token does not match the action target")
+        );
     }
 
     #[test]

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -1342,6 +1342,86 @@ async fn run_cu(client: &reqwest::Client, config: &Config, raw: &[String]) -> Re
                 call_tool(client, config, "execute_cu_actions", Value::Object(map)).await?;
             print_tool_response(response, config, output)?;
         }
+        "task" | "bounded" => {
+            ensure_help(&raw[1..], help_cu_task)?;
+            let args = parse_command_args(
+                &raw[1..],
+                &[
+                    "--task",
+                    "--mode",
+                    "--attempt",
+                    "--workspace",
+                    "--display-id",
+                    "--target",
+                    "--capture-generation",
+                    "--prior-receipt",
+                    "--prior-count",
+                    "--prior-transcript",
+                    "--observation-sha256",
+                ],
+                &[],
+            )?;
+            let task = args
+                .one("--task")
+                .map(str::to_string)
+                .or_else(|| (!args.positional.is_empty()).then(|| args.positional.join(" ")))
+                .ok_or_else(|| "cu task requires TASK or --task".to_string())?;
+            let required = |flag: &str| {
+                args.one(flag)
+                    .map(str::to_string)
+                    .ok_or_else(|| format!("cu task requires {flag}"))
+            };
+            let mode = required("--mode")?;
+            if !matches!(mode.as_str(), "stage" | "attest") {
+                return Err("--mode must be stage or attest".to_string());
+            }
+            let display_id = required("--display-id")?
+                .parse::<u32>()
+                .map_err(|_| "--display-id must be an unsigned 32-bit integer".to_string())?;
+            let mut map = Map::new();
+            map.insert("task".to_string(), Value::String(task));
+            map.insert("mode".to_string(), Value::String(mode));
+            map.insert(
+                "attempt_id".to_string(),
+                Value::String(required("--attempt")?),
+            );
+            map.insert(
+                "workspace_id".to_string(),
+                Value::String(required("--workspace")?),
+            );
+            map.insert("display_id".to_string(), Value::from(display_id));
+            map.insert(
+                "display_target".to_string(),
+                Value::String(required("--target")?),
+            );
+            map.insert(
+                "capture_generation".to_string(),
+                Value::String(required("--capture-generation")?),
+            );
+            insert_string(&mut map, "prior_receipt_id", args.one("--prior-receipt"));
+            insert_string(
+                &mut map,
+                "prior_transcript_sha256",
+                args.one("--prior-transcript"),
+            );
+            insert_string(
+                &mut map,
+                "observation_sha256",
+                args.one("--observation-sha256"),
+            );
+            if let Some(raw_count) = args.one("--prior-count") {
+                let count = raw_count
+                    .parse::<u64>()
+                    .map_err(|_| "--prior-count must be an unsigned integer".to_string())?;
+                map.insert(
+                    "prior_transcript_event_count".to_string(),
+                    Value::from(count),
+                );
+            }
+            let response =
+                call_tool(client, config, "run_bounded_cu_task", Value::Object(map)).await?;
+            print_tool_response(response, config, None)?;
+        }
         "screenshot" => {
             let next = std::iter::once("screenshot".to_string())
                 .chain(raw[1..].iter().cloned())
@@ -6078,6 +6158,7 @@ fn help_cu() {
     println!(
         "Usage:\n\
   intendant ctl cu actions --actions JSON|@file|- [--target TARGET] [--observe pixels|ax|auto|none] [--annotate] [--settle MS] [--coordinate-space pixel|normalized_1000] [--output out.png]\n\
+  intendant ctl cu task TASK --mode stage|attest --attempt ID --workspace ID --display-id N --target display_N --capture-generation ID [attest lineage flags]\n\
   intendant ctl cu screenshot [--target TARGET] [--output out.png]\n\
   intendant ctl cu elements [--target TARGET] [--format text|json] [--full-values]\n\
 \n\
@@ -6090,6 +6171,16 @@ Targets: user_session (needs display grant), 99/display_99 (virtual).\n\
 Omit to auto-detect: a live agent virtual display when one exists, else the user session.\n\
 If CU calls fail, `intendant ctl display status` reports per-layer readiness\n\
 (grant, OS permissions, display, input) with fixes."
+    );
+}
+
+fn help_cu_task() {
+    println!(
+        "Usage: intendant ctl cu task TASK --mode stage|attest --attempt ID --workspace ID --display-id N --target display_N --capture-generation ID [--prior-receipt ID --prior-count N --prior-transcript SHA256 --observation-sha256 SHA256]\n\
+Runs a synchronous CU-only task against the exact daemon-created display generation and\n\
+attempt-owned browser lease. stage permits bounded native computer actions; attest is\n\
+strictly observation-only and requires all four lineage flags. The provider receives no\n\
+shell, filesystem, browser API, delegation, function tools, or escalation capability."
     );
 }
 

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -1355,9 +1355,6 @@ async fn run_cu(client: &reqwest::Client, config: &Config, raw: &[String]) -> Re
                     "--target",
                     "--capture-generation",
                     "--prior-receipt",
-                    "--prior-count",
-                    "--prior-transcript",
-                    "--observation-sha256",
                 ],
                 &[],
             )?;
@@ -1399,25 +1396,6 @@ async fn run_cu(client: &reqwest::Client, config: &Config, raw: &[String]) -> Re
                 Value::String(required("--capture-generation")?),
             );
             insert_string(&mut map, "prior_receipt_id", args.one("--prior-receipt"));
-            insert_string(
-                &mut map,
-                "prior_transcript_sha256",
-                args.one("--prior-transcript"),
-            );
-            insert_string(
-                &mut map,
-                "observation_sha256",
-                args.one("--observation-sha256"),
-            );
-            if let Some(raw_count) = args.one("--prior-count") {
-                let count = raw_count
-                    .parse::<u64>()
-                    .map_err(|_| "--prior-count must be an unsigned integer".to_string())?;
-                map.insert(
-                    "prior_transcript_event_count".to_string(),
-                    Value::from(count),
-                );
-            }
             let response =
                 call_tool(client, config, "run_bounded_cu_task", Value::Object(map)).await?;
             print_tool_response(response, config, None)?;
@@ -6158,7 +6136,7 @@ fn help_cu() {
     println!(
         "Usage:\n\
   intendant ctl cu actions --actions JSON|@file|- [--target TARGET] [--observe pixels|ax|auto|none] [--annotate] [--settle MS] [--coordinate-space pixel|normalized_1000] [--output out.png]\n\
-  intendant ctl cu task TASK --mode stage|attest --attempt ID --workspace ID --display-id N --target display_N --capture-generation ID [attest lineage flags]\n\
+  intendant ctl cu task TASK --mode stage|attest --attempt ID --workspace ID --display-id N --target display_N --capture-generation ID [--prior-receipt ID]\n\
   intendant ctl cu screenshot [--target TARGET] [--output out.png]\n\
   intendant ctl cu elements [--target TARGET] [--format text|json] [--full-values]\n\
 \n\
@@ -6176,10 +6154,11 @@ If CU calls fail, `intendant ctl display status` reports per-layer readiness\n\
 
 fn help_cu_task() {
     println!(
-        "Usage: intendant ctl cu task TASK --mode stage|attest --attempt ID --workspace ID --display-id N --target display_N --capture-generation ID [--prior-receipt ID --prior-count N --prior-transcript SHA256 --observation-sha256 SHA256]\n\
+        "Usage: intendant ctl cu task TASK --mode stage|attest --attempt ID --workspace ID --display-id N --target display_N --capture-generation ID [--prior-receipt ID]\n\
 Runs a synchronous CU-only task against the exact daemon-created display generation and\n\
 attempt-owned browser lease. stage permits bounded native computer actions; attest is\n\
-strictly observation-only and requires all four lineage flags. The provider receives no\n\
+strictly observation-only and requires a stage receipt issued by this daemon lifetime.\n\
+Transcript and screenshot lineage are derived and verified internally. The provider receives no\n\
 shell, filesystem, browser API, delegation, function tools, or escalation capability."
     );
 }

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -14,6 +14,7 @@ mod backend_install;
 mod backend_model_catalog;
 mod background_tasks;
 mod boot_readopt;
+mod bounded_cu_task;
 mod browser_workspace;
 #[path = "../../build_info.rs"]
 mod build_info;

--- a/src/bin/caller/mcp/facade/registry.rs
+++ b/src/bin/caller/mcp/facade/registry.rs
@@ -844,6 +844,51 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
         help: "Execute a JSON array of computer-use actions",
     },
     CommandSpec {
+        path: &["cu", "task"],
+        lane: RiskLane::Act,
+        tool: "run_bounded_cu_task",
+        seed: "{}",
+        positionals: &[p_str("TASK", "task", true, true)],
+        flags: &[
+            flag!("mode", "mode", Str, "stage or attest"),
+            flag!("attempt", "attempt_id", Str, "exact Scout attempt id"),
+            flag!("workspace", "workspace_id", Str, "exact browser workspace id"),
+            flag!("display-id", "display_id", U64, "daemon virtual display id"),
+            flag!("target", "display_target", Str, "canonical display_N target"),
+            flag!(
+                "capture-generation",
+                "capture_generation",
+                Str,
+                "opaque display generation"
+            ),
+            flag!(
+                "prior-receipt",
+                "prior_receipt_id",
+                Str,
+                "stage receipt continued by attest"
+            ),
+            flag!(
+                "prior-count",
+                "prior_transcript_event_count",
+                U64,
+                "stage transcript event count"
+            ),
+            flag!(
+                "prior-transcript",
+                "prior_transcript_sha256",
+                Str,
+                "stage transcript SHA-256"
+            ),
+            flag!(
+                "observation-sha256",
+                "observation_sha256",
+                Str,
+                "authenticated pre-attestation observation SHA-256"
+            ),
+        ],
+        help: "Run a bounded CU-only stage or read-only attestation task",
+    },
+    CommandSpec {
         path: &["display", "create"],
         lane: RiskLane::Act,
         tool: "create_virtual_display",

--- a/src/bin/caller/mcp/facade/registry.rs
+++ b/src/bin/caller/mcp/facade/registry.rs
@@ -867,24 +867,6 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
                 Str,
                 "stage receipt continued by attest"
             ),
-            flag!(
-                "prior-count",
-                "prior_transcript_event_count",
-                U64,
-                "stage transcript event count"
-            ),
-            flag!(
-                "prior-transcript",
-                "prior_transcript_sha256",
-                Str,
-                "stage transcript SHA-256"
-            ),
-            flag!(
-                "observation-sha256",
-                "observation_sha256",
-                Str,
-                "authenticated pre-attestation observation SHA-256"
-            ),
         ],
         help: "Run a bounded CU-only stage or read-only attestation task",
     },

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -72,6 +72,7 @@ pub(crate) use tools_ask::{
 // clean the process-global registry through this.
 #[cfg(test)]
 pub(crate) use tools_ask::unregister_pending_ask;
+mod tools_bounded_cu;
 mod tools_codex_cloud;
 mod tools_display;
 mod tools_events;
@@ -997,6 +998,12 @@ impl IntendantServer {
                 let params = parse_params::<ReleaseBrowserWorkspaceParams>(args)?;
                 Ok(text_tool_result(
                     self.release_browser_workspace(params).await,
+                ))
+            }
+            "run_bounded_cu_task" => {
+                let Parameters(params) = parse_params::<RunBoundedCuTaskParams>(args)?;
+                Ok(text_tool_result(
+                    self.run_bounded_cu_task_as_caller(params, caller).await,
                 ))
             }
             "terminal_list" => Ok(text_tool_result(

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -154,6 +154,9 @@ pub struct McpAppState {
     pub event_ring: Option<std::sync::Arc<crate::event_ring::EventRing>>,
     /// Directory for screenshot output.
     pub screenshot_dir: Option<std::path::PathBuf>,
+    /// Dedicated native computer-use configuration for bounded CU tasks.
+    /// The lane never inherits arbitrary agent tools from the active session.
+    pub computer_use_config: crate::project::ComputerUseConfig,
     /// Persistent counter for screenshot filenames (avoids overwriting).
     pub screenshot_counter: std::sync::atomic::AtomicU64,
     /// External agent backend selected via web UI (deferred: takes effect on next task).
@@ -345,6 +348,7 @@ impl McpAppState {
             user_display_activation_pending: std::collections::HashMap::new(),
             display_capture_ready: HashSet::new(),
             screenshot_dir: None,
+            computer_use_config: crate::project::ComputerUseConfig::default(),
             screenshot_counter: std::sync::atomic::AtomicU64::new(0),
             external_agent: None,
             configured_codex_managed_context: false,

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -77,6 +77,8 @@ pub(crate) fn fission_tool(name: &str) -> bool {
 ///   `wait`/`hold_key` millisecond durations verbatim
 ///   (`computer_use.rs`), so a sequence legitimately outlives the
 ///   window (the 60 s cloud CU round trip also rides inside it).
+/// - `run_bounded_cu_task` — the proof-stage deadline is 180 s and its
+///   attestation deadline is 45 s, both including provider round trips.
 /// - `peer_execute_cu_actions` — the same caller-paced actions run on
 ///   a federated peer, bounded only by `PEER_MCP_TIMEOUT` (120 s).
 /// - `events` — the long-poll chunk may sit the full
@@ -91,12 +93,13 @@ pub(crate) fn fission_tool(name: &str) -> bool {
 /// codex thread-action waits (20 s) and the remaining peer round
 /// trips (sub-second lookups under `PEER_MCP_TIMEOUT`'s transport
 /// bound — a bound is not a hold).
-pub(crate) const MCP_HELD_POST_TOOLS: [&str; 8] = [
+pub(crate) const MCP_HELD_POST_TOOLS: [&str; 9] = [
     "ask_user",
     "request_user_display",
     "spawn_live_audio",
     "fission_control",
     "execute_cu_actions",
+    "run_bounded_cu_task",
     "peer_execute_cu_actions",
     "events",
     "remote_command",

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -453,7 +453,8 @@ pub(crate) fn mcp_tool_operation(name: &str) -> crate::peer::access_policy::Peer
         | "grant_user_display"
         | "revoke_user_display"
         | "request_shared_view_input"
-        | "execute_cu_actions" => PeerOperation::DisplayInput,
+        | "execute_cu_actions"
+        | "run_bounded_cu_task" => PeerOperation::DisplayInput,
         // Browser workspaces, live audio, autonomy/verbosity, lifecycle, and
         // controller-restart orchestration are runtime-control surfaces.
         "create_browser_workspace"
@@ -894,6 +895,14 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
             "destroy_virtual_display",
             "Destroy one exact daemon-owned virtual-display generation. Requires the display_id and capture_generation returned by create_virtual_display, closes bound browser workspaces first, and refuses stale generations without touching the live display.",
             DestroyVirtualDisplayParams
+        ),
+    );
+    push(
+        "run_bounded_cu_task",
+        manual_http_tool_definition!(
+            "run_bounded_cu_task",
+            "Run one owner-only synchronous computer-use task on an exact daemon-owned virtual-display generation and exact attempt-leased local CDP workspace. stage permits bounded native CU actions; attest is observation-only. No shell, filesystem, browser API, delegation, function tools, or escalation is exposed. Returns a compact lineage-bound JSON receipt.",
+            RunBoundedCuTaskParams
         ),
     );
     push(
@@ -1518,6 +1527,45 @@ mod tests {
             manual_description,
             attr.description.as_deref().unwrap_or_default(),
             "display_readiness manual HTTP description drifted from its #[tool] attribute"
+        );
+    }
+
+    #[test]
+    fn bounded_cu_task_is_owner_only_and_description_stays_in_sync() {
+        for profile in [
+            Some("core"),
+            Some("codex-core"),
+            Some("cli"),
+            Some("minimal"),
+            Some("screen"),
+            Some("display"),
+            Some("managed"),
+            Some("facade"),
+        ] {
+            assert!(
+                !tool_allowed_for_profile("run_bounded_cu_task", false, profile),
+                "bounded CU must not be advertised to profile {profile:?}"
+            );
+        }
+        for profile in [None, Some("full")] {
+            assert!(tool_allowed_for_profile(
+                "run_bounded_cu_task",
+                false,
+                profile
+            ));
+        }
+        let mut manual = Vec::new();
+        append_manual_http_tool_definitions(&mut manual, false, Some("full"));
+        let manual_description = manual
+            .iter()
+            .find(|tool| tool["name"] == "run_bounded_cu_task")
+            .and_then(|tool| tool["description"].as_str())
+            .expect("missing manual HTTP definition for run_bounded_cu_task");
+        let attr = IntendantServer::run_bounded_cu_task_tool_attr();
+        assert_eq!(
+            manual_description,
+            attr.description.as_deref().unwrap_or_default(),
+            "run_bounded_cu_task manual HTTP description drifted from its #[tool] attribute"
         );
     }
 

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -663,15 +663,6 @@ pub struct RunBoundedCuTaskParams {
     /// Stage receipt continued by an attestation; forbidden in stage mode.
     #[serde(default)]
     pub prior_receipt_id: Option<String>,
-    /// Stage transcript count continued by an attestation.
-    #[serde(default)]
-    pub prior_transcript_event_count: Option<u64>,
-    /// Stage transcript digest continued by an attestation.
-    #[serde(default)]
-    pub prior_transcript_sha256: Option<String>,
-    /// Authenticated observation digest that precedes read-only attestation.
-    #[serde(default)]
-    pub observation_sha256: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -643,6 +643,37 @@ pub struct DestroyVirtualDisplayParams {
     pub note: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
+pub struct RunBoundedCuTaskParams {
+    /// `stage` permits bounded native computer input; `attest` is strictly
+    /// observation-only after its internally captured initial frame.
+    pub mode: crate::bounded_cu_task::BoundedCuTaskMode,
+    /// Exact Scout attempt that owns the browser-workspace lease.
+    pub attempt_id: String,
+    /// Exact ready, local CDP workspace created for this attempt.
+    pub workspace_id: String,
+    /// Numeric daemon-created virtual-display ID.
+    pub display_id: u32,
+    /// Canonical `display_N` target; must agree with `display_id`.
+    pub display_target: String,
+    /// Opaque generation returned by the matching display-create operation.
+    pub capture_generation: String,
+    /// Fully primed task and required JSON result shape.
+    pub task: String,
+    /// Stage receipt continued by an attestation; forbidden in stage mode.
+    #[serde(default)]
+    pub prior_receipt_id: Option<String>,
+    /// Stage transcript count continued by an attestation.
+    #[serde(default)]
+    pub prior_transcript_event_count: Option<u64>,
+    /// Stage transcript digest continued by an attestation.
+    #[serde(default)]
+    pub prior_transcript_sha256: Option<String>,
+    /// Authenticated observation digest that precedes read-only attestation.
+    #[serde(default)]
+    pub observation_sha256: Option<String>,
+}
+
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct RevokeUserDisplayParams {
     /// User session display ID to revoke. Omit for the primary display (0).

--- a/src/bin/caller/mcp/tools_bounded_cu.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu.rs
@@ -1,0 +1,492 @@
+//! The synchronous, exact-resource-bound computer-use lane used by Scout CDN
+//! proof capture. This is intentionally separate from general task dispatch.
+
+use super::*;
+use async_trait::async_trait;
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use crate::bounded_cu_task::{
+    run_bounded_cu_task as execute_bounded_cu_task, validate_bounded_cu_task_request,
+    BoundedCuActionExecutor, BoundedCuActionOutcome, BoundedCuTaskError, BoundedCuTaskRequest,
+};
+use crate::browser_workspace::{
+    BrowserWorkspace, BrowserWorkspaceProvider, BrowserWorkspaceStatus,
+};
+use crate::computer_use::{
+    execute_actions, summarize_results_for_model, CuAction, CuActionStatus, CuExecOptions,
+    DisplayBackend, DisplayTarget,
+};
+use crate::conversation::ImageData;
+
+const SCOUT_CDN_LEASE_KIND: &str = "scout_cdn_capture";
+
+fn active_bounded_displays() -> &'static Mutex<HashSet<(u32, String)>> {
+    static ACTIVE: OnceLock<Mutex<HashSet<(u32, String)>>> = OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+#[derive(Debug)]
+struct BoundedDisplayExecutionLease {
+    display_id: u32,
+    capture_generation: String,
+}
+
+impl BoundedDisplayExecutionLease {
+    fn acquire(display_id: u32, capture_generation: &str) -> Result<Self, BoundedCuTaskError> {
+        let mut active = active_bounded_displays().lock().map_err(|_| {
+            BoundedCuTaskError::new(
+                "bounded-cu-execution-lease-unavailable",
+                "bounded CU execution-lease registry was poisoned",
+                false,
+            )
+        })?;
+        let key = (display_id, capture_generation.to_string());
+        if !active.insert(key) {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-execution-already-active",
+                "another bounded CU task already owns this exact display generation",
+                true,
+            ));
+        }
+        Ok(Self {
+            display_id,
+            capture_generation: capture_generation.to_string(),
+        })
+    }
+}
+
+impl Drop for BoundedDisplayExecutionLease {
+    fn drop(&mut self) {
+        if let Ok(mut active) = active_bounded_displays().lock() {
+            active.remove(&(self.display_id, self.capture_generation.clone()));
+        }
+    }
+}
+
+struct NativeBoundedCuExecutor {
+    target: DisplayTarget,
+    backend: DisplayBackend,
+    scratch_dir: std::path::PathBuf,
+    action_counter: u64,
+    session_registry: Option<crate::display::SharedSessionRegistry>,
+    params: RunBoundedCuTaskParams,
+    bus: crate::event::EventBus,
+}
+
+#[async_trait]
+impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
+    async fn execute(
+        &mut self,
+        actions: &[CuAction],
+    ) -> Result<BoundedCuActionOutcome, BoundedCuTaskError> {
+        let mut results = Vec::with_capacity(actions.len());
+        let mut screenshot = None;
+        for action in actions {
+            validate_resource_binding(&self.params, &self.bus).await?;
+            let outcome = execute_actions(
+                std::slice::from_ref(action),
+                self.target,
+                self.backend,
+                &self.scratch_dir,
+                &mut self.action_counter,
+                &self.session_registry,
+                None,
+                false,
+                None,
+                CuExecOptions::default(),
+            )
+            .await;
+            if outcome.results.len() != 1 {
+                return Err(BoundedCuTaskError::new(
+                    "bounded-cu-action-cardinality-mismatch",
+                    "native computer use did not return exactly one result for one action",
+                    false,
+                ));
+            }
+            let action_screenshot = outcome.last_screenshot().cloned().ok_or_else(|| {
+                BoundedCuTaskError::new(
+                    "bounded-cu-observation-missing",
+                    "native computer-use action returned no trailing screenshot",
+                    false,
+                )
+            })?;
+            if outcome.results[0].status == CuActionStatus::Failed {
+                return Err(BoundedCuTaskError::new(
+                    "bounded-cu-action-failed",
+                    "native computer-use action failed; later actions were not executed",
+                    false,
+                ));
+            }
+            screenshot = Some(action_screenshot);
+            results.extend(outcome.results);
+            validate_resource_binding(&self.params, &self.bus).await?;
+        }
+        let screenshot = screenshot.ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-observation-missing",
+                "native computer-use batch returned no trailing screenshot",
+                false,
+            )
+        })?;
+        Ok(BoundedCuActionOutcome {
+            model_summary: summarize_results_for_model(actions, &results),
+            screenshot: ImageData {
+                media_type: "image/png".to_string(),
+                data: screenshot.base64_png,
+            },
+            statuses: results
+                .iter()
+                .map(|result| result.status)
+                .collect::<Vec<CuActionStatus>>(),
+        })
+    }
+}
+
+impl IntendantServer {
+    #[tool(
+        description = "Run one owner-only synchronous computer-use task on an exact daemon-owned virtual-display generation and exact attempt-leased local CDP workspace. stage permits bounded native CU actions; attest is observation-only. No shell, filesystem, browser API, delegation, function tools, or escalation is exposed. Returns a compact lineage-bound JSON receipt."
+    )]
+    pub(crate) async fn run_bounded_cu_task(
+        &self,
+        Parameters(params): Parameters<RunBoundedCuTaskParams>,
+    ) -> String {
+        self.run_bounded_cu_task_as_caller(params, ToolCallerTrust::OwnerSurface)
+            .await
+    }
+
+    pub(crate) async fn run_bounded_cu_task_as_caller(
+        &self,
+        params: RunBoundedCuTaskParams,
+        caller: ToolCallerTrust,
+    ) -> String {
+        if let Err(error) = require_owner_surface(caller) {
+            return bounded_error_json(error);
+        }
+        match self.run_bounded_cu_task_inner(params).await {
+            Ok(receipt) => serde_json::json!({ "ok": true, "receipt": receipt }).to_string(),
+            Err(error) => bounded_error_json(error),
+        }
+    }
+
+    async fn run_bounded_cu_task_inner(
+        &self,
+        params: RunBoundedCuTaskParams,
+    ) -> Result<crate::bounded_cu_task::BoundedCuTaskReceipt, BoundedCuTaskError> {
+        let request = BoundedCuTaskRequest {
+            mode: params.mode,
+            attempt_id: params.attempt_id.clone(),
+            workspace_id: params.workspace_id.clone(),
+            display_id: params.display_id,
+            display_target: params.display_target.clone(),
+            capture_generation: params.capture_generation.clone(),
+            task: params.task.clone(),
+            prior_receipt_id: params.prior_receipt_id.clone(),
+            prior_transcript_event_count: params.prior_transcript_event_count,
+            prior_transcript_sha256: params.prior_transcript_sha256.clone(),
+            observation_sha256: params.observation_sha256.clone(),
+        };
+        validate_bounded_cu_task_request(&request)?;
+        validate_resource_binding(&params, &self.bus).await?;
+        let _execution_lease =
+            BoundedDisplayExecutionLease::acquire(params.display_id, &params.capture_generation)?;
+        let (cu_config, session_registry, action_counter) = {
+            let state = self.state.read().await;
+            (
+                state.computer_use_config.clone(),
+                state.session_registry.clone(),
+                state
+                    .screenshot_counter
+                    .fetch_add(1_000, std::sync::atomic::Ordering::Relaxed),
+            )
+        };
+        let target = DisplayTarget::Virtual {
+            id: params.display_id,
+        };
+        let dimensions = crate::computer_use::target_pixel_size(target, &session_registry).await;
+        if dimensions.0 == 0 || dimensions.1 == 0 {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-display-size-unavailable",
+                "bound virtual display returned an invalid pixel size",
+                false,
+            ));
+        }
+        let mut provider =
+            crate::provider::select_bounded_cu_provider(&cu_config).map_err(|error| {
+                BoundedCuTaskError::new("bounded-cu-provider-unavailable", error.to_string(), true)
+            })?;
+        provider.set_cu_display(dimensions);
+        let scratch = create_private_scratch()?;
+        validate_private_scratch(scratch.path())?;
+        let mut executor = NativeBoundedCuExecutor {
+            target,
+            backend: DisplayBackend::from_config(&cu_config.backend),
+            scratch_dir: scratch.path().to_path_buf(),
+            action_counter,
+            session_registry,
+            params: params.clone(),
+            bus: self.bus.clone(),
+        };
+        let task_result = execute_bounded_cu_task(provider.as_ref(), &mut executor, request).await;
+        let final_binding = validate_resource_binding(&params, &self.bus).await;
+        let cleanup = scratch.close().map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-private-scratch-cleanup-failed",
+                format!("cannot remove private CU scratch directory: {error}"),
+                false,
+            )
+        });
+        match (task_result, final_binding, cleanup) {
+            (Ok(receipt), Ok(()), Ok(())) => Ok(receipt),
+            (Err(error), Ok(()), Ok(())) => Err(error),
+            (Ok(_), Err(error), Ok(())) | (Ok(_), Ok(()), Err(error)) => Err(error),
+            (Err(task), Err(binding), Ok(())) => Err(BoundedCuTaskError::new(
+                "bounded-cu-task-and-binding-failed",
+                format!("{}; additionally: {}", task.message, binding.message),
+                false,
+            )),
+            (Err(task), Ok(()), Err(cleanup)) => Err(BoundedCuTaskError::new(
+                "bounded-cu-task-and-cleanup-failed",
+                format!("{}; additionally: {}", task.message, cleanup.message),
+                false,
+            )),
+            (Ok(_), Err(binding), Err(cleanup)) => Err(BoundedCuTaskError::new(
+                "bounded-cu-binding-and-cleanup-failed",
+                format!("{}; additionally: {}", binding.message, cleanup.message),
+                false,
+            )),
+            (Err(task), Err(binding), Err(cleanup)) => Err(BoundedCuTaskError::new(
+                "bounded-cu-task-binding-and-cleanup-failed",
+                format!(
+                    "{}; additionally: {}; additionally: {}",
+                    task.message, binding.message, cleanup.message
+                ),
+                false,
+            )),
+        }
+    }
+}
+
+fn require_owner_surface(caller: ToolCallerTrust) -> Result<(), BoundedCuTaskError> {
+    if caller == ToolCallerTrust::OwnerSurface {
+        Ok(())
+    } else {
+        Err(BoundedCuTaskError::new(
+            "bounded-cu-owner-surface-required",
+            "bounded CU tasks are restricted to an authenticated owner surface",
+            false,
+        ))
+    }
+}
+
+async fn validate_resource_binding(
+    params: &RunBoundedCuTaskParams,
+    bus: &crate::event::EventBus,
+) -> Result<(), BoundedCuTaskError> {
+    if params.display_target != format!("display_{}", params.display_id)
+        || !crate::virtual_display::process_owns_browser_bindable_display_generation(
+            params.display_id,
+            &params.capture_generation,
+        )
+    {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-display-generation-mismatch",
+            "display ID, target, and live daemon-owned generation did not match",
+            false,
+        ));
+    }
+    let workspaces = crate::browser_workspace::list_workspaces(bus).await;
+    let workspace = workspaces
+        .iter()
+        .find(|workspace| workspace.id == params.workspace_id)
+        .ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-workspace-missing",
+                "exact browser workspace was not found",
+                false,
+            )
+        })?;
+    validate_workspace(workspace, params)
+}
+
+fn validate_workspace(
+    workspace: &BrowserWorkspace,
+    params: &RunBoundedCuTaskParams,
+) -> Result<(), BoundedCuTaskError> {
+    let exact_lease = workspace.lease.as_ref().is_some_and(|lease| {
+        lease.holder_id == params.attempt_id && lease.holder_kind == SCOUT_CDN_LEASE_KIND
+    });
+    if workspace.status != BrowserWorkspaceStatus::Ready
+        || !workspace.placement.is_local()
+        || workspace.provider != BrowserWorkspaceProvider::Cdp
+        || workspace.display_target.as_deref() != Some(params.display_target.as_str())
+        || workspace.owner_session_id.as_deref() != Some(params.attempt_id.as_str())
+        || workspace.process_id.is_none()
+        || workspace.cdp_http_url.is_none()
+        || workspace.active_target_id.is_none()
+        || !exact_lease
+    {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-workspace-binding-mismatch",
+            "workspace was not the exact ready, local, display-bound, attempt-owned CDP lease",
+            false,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_private_scratch(path: &std::path::Path) -> Result<(), BoundedCuTaskError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        BoundedCuTaskError::new(
+            "bounded-cu-private-scratch-failed",
+            format!("cannot inspect private CU scratch directory: {error}"),
+            false,
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-private-scratch-unsafe",
+            "CU scratch path was not a non-symlink directory",
+            false,
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        // SAFETY: `geteuid(2)` takes no arguments and cannot fail.
+        let effective_uid = unsafe { libc::geteuid() };
+        if metadata.mode() & 0o7777 != 0o700 || metadata.uid() != effective_uid {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-private-scratch-unsafe",
+                "CU scratch directory was not current-user-owned mode 0700",
+                false,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn create_private_scratch() -> Result<tempfile::TempDir, BoundedCuTaskError> {
+    let mut builder = tempfile::Builder::new();
+    builder.prefix("intendant-bounded-cu-");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    builder.tempdir().map_err(|error| {
+        BoundedCuTaskError::new(
+            "bounded-cu-private-scratch-failed",
+            format!("cannot create private CU scratch directory: {error}"),
+            false,
+        )
+    })
+}
+
+fn bounded_error_json(error: BoundedCuTaskError) -> String {
+    serde_json::json!({
+        "ok": false,
+        "error": {
+            "code": error.code,
+            "message": error.message,
+            "retryable": error.retryable,
+        }
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params() -> RunBoundedCuTaskParams {
+        RunBoundedCuTaskParams {
+            mode: crate::bounded_cu_task::BoundedCuTaskMode::Stage,
+            attempt_id: "attempt-1".to_string(),
+            workspace_id: "bw-1".to_string(),
+            display_id: 99,
+            display_target: "display_99".to_string(),
+            capture_generation: "vdcg-1".to_string(),
+            task: "stage".to_string(),
+            prior_receipt_id: None,
+            prior_transcript_event_count: None,
+            prior_transcript_sha256: None,
+            observation_sha256: None,
+        }
+    }
+
+    fn workspace() -> BrowserWorkspace {
+        BrowserWorkspace {
+            id: "bw-1".to_string(),
+            label: "proof".to_string(),
+            url: Some("https://example.com".to_string()),
+            provider: BrowserWorkspaceProvider::Cdp,
+            requested_provider: BrowserWorkspaceProvider::Cdp,
+            placement: crate::browser_workspace::BrowserWorkspacePlacement::local(),
+            status: BrowserWorkspaceStatus::Ready,
+            preview_mode: crate::browser_workspace::BrowserWorkspacePreviewMode::Semantic,
+            owner_session_id: Some("attempt-1".to_string()),
+            display_target: Some("display_99".to_string()),
+            profile_dir: Some("/tmp/profile".to_string()),
+            browser_executable: Some("/usr/bin/chromium".to_string()),
+            browser_executable_source: Some("managed".to_string()),
+            process_id: Some(10),
+            debugging_port: Some(9222),
+            cdp_http_url: Some("http://127.0.0.1:9222".to_string()),
+            cdp_ws_url: Some("ws://127.0.0.1:9222/devtools/page/1".to_string()),
+            active_target_id: Some("page-1".to_string()),
+            lease: Some(crate::browser_workspace::BrowserWorkspaceLease {
+                holder_id: "attempt-1".to_string(),
+                holder_kind: SCOUT_CDN_LEASE_KIND.to_string(),
+                acquired_at: "2026-09-01T00:00:00Z".to_string(),
+                note: None,
+            }),
+            message: Some("ready".to_string()),
+            created_at: "2026-09-01T00:00:00Z".to_string(),
+            updated_at: "2026-09-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn workspace_binding_requires_attempt_owner_and_exact_lease() {
+        let params = params();
+        let mut workspace = workspace();
+        validate_workspace(&workspace, &params).unwrap();
+
+        workspace.lease.as_mut().unwrap().holder_id = "other".to_string();
+        assert_eq!(
+            validate_workspace(&workspace, &params).unwrap_err().code,
+            "bounded-cu-workspace-binding-mismatch"
+        );
+    }
+
+    #[test]
+    fn private_scratch_is_mode_0700() {
+        let scratch = create_private_scratch().unwrap();
+        validate_private_scratch(scratch.path()).unwrap();
+    }
+
+    #[test]
+    fn scoped_callers_are_rejected_before_resource_lookup() {
+        assert!(require_owner_surface(ToolCallerTrust::OwnerSurface).is_ok());
+        assert_eq!(
+            require_owner_surface(ToolCallerTrust::Scoped)
+                .unwrap_err()
+                .code,
+            "bounded-cu-owner-surface-required"
+        );
+    }
+
+    #[test]
+    fn exact_display_generation_allows_only_one_bounded_task() {
+        let first = BoundedDisplayExecutionLease::acquire(424_242, "vdcg-test-exclusive").unwrap();
+        assert_eq!(
+            BoundedDisplayExecutionLease::acquire(424_242, "vdcg-test-exclusive")
+                .unwrap_err()
+                .code,
+            "bounded-cu-execution-already-active"
+        );
+        drop(first);
+        BoundedDisplayExecutionLease::acquire(424_242, "vdcg-test-exclusive").unwrap();
+    }
+}

--- a/src/bin/caller/mcp/tools_bounded_cu.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu.rs
@@ -5,16 +5,17 @@ use super::*;
 use async_trait::async_trait;
 
 use crate::bounded_cu_task::{
-    run_bounded_cu_task as execute_bounded_cu_task, validate_bounded_cu_task_request,
-    BoundedCuActionExecutor, BoundedCuActionOutcome, BoundedCuTaskError, BoundedCuTaskRequest,
+    remember_issued_stage_receipt, run_bounded_cu_task as execute_bounded_cu_task,
+    validate_bounded_cu_task_request, BoundedCuActionExecutor, BoundedCuActionOutcome,
+    BoundedCuTaskError, BoundedCuTaskRequest,
 };
 use crate::browser_workspace::{
     BrowserWorkspace, BrowserWorkspaceProvider, BrowserWorkspaceStatus,
 };
 use crate::computer_use::{
-    execute_actions_with_exclusive_access, summarize_results_for_model, CuAction, CuActionResult,
-    CuActionStatus, CuExecOptions, DisplayBackend, DisplayTarget, ScreenshotData,
-    VirtualDisplayExclusiveAccess,
+    bounded_action_safety_releases, execute_actions_with_exclusive_access,
+    summarize_results_for_model, CuAction, CuActionResult, CuActionStatus, CuExecOptions,
+    DisplayBackend, DisplayTarget, ScreenshotData, VirtualDisplayExclusiveAccess,
 };
 use crate::conversation::ImageData;
 
@@ -28,7 +29,76 @@ struct NativeBoundedCuExecutor {
     session_registry: Option<crate::display::SharedSessionRegistry>,
     params: RunBoundedCuTaskParams,
     bus: crate::event::EventBus,
-    display_access: VirtualDisplayExclusiveAccess,
+    display_access: Option<VirtualDisplayExclusiveAccess>,
+    proof_session: std::sync::Arc<crate::display::DisplaySession>,
+    pending_safety_releases: Vec<crate::display::InputEvent>,
+}
+
+impl NativeBoundedCuExecutor {
+    async fn validate_proof_session_liveness(&self) -> Result<(), BoundedCuTaskError> {
+        if self.proof_session.capture_bridge_running().await {
+            Ok(())
+        } else {
+            Err(BoundedCuTaskError::new(
+                "bounded-cu-capture-session-unavailable",
+                "bound display capture stopped during the proof task",
+                false,
+            ))
+        }
+    }
+
+    async fn release_pending_input_edges(&mut self) -> Result<(), BoundedCuTaskError> {
+        // Keep the authoritative list on `self` until every release returns.
+        // If this cleanup future is itself cancelled, Drop can retry the full
+        // idempotent release set while retaining exclusive display access.
+        let releases = self.pending_safety_releases.clone();
+        let mut errors = Vec::new();
+        for release in releases {
+            if let Err(error) = self.proof_session.inject_input(release).await {
+                errors.push(error.to_string());
+            }
+        }
+        if errors.is_empty() {
+            self.pending_safety_releases.clear();
+            Ok(())
+        } else {
+            Err(BoundedCuTaskError::new(
+                "bounded-cu-input-safety-release-failed",
+                format!(
+                    "could not release every possibly-held direct input edge: {}",
+                    errors.join("; ")
+                ),
+                false,
+            ))
+        }
+    }
+}
+
+impl Drop for NativeBoundedCuExecutor {
+    fn drop(&mut self) {
+        if self.pending_safety_releases.is_empty() {
+            return;
+        }
+        let releases = std::mem::take(&mut self.pending_safety_releases);
+        let Some(display_access) = self.display_access.take() else {
+            return;
+        };
+        let session = std::sync::Arc::clone(&self.proof_session);
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            eprintln!(
+                "[bounded-cu] no Tokio runtime was available for cancellation safety releases"
+            );
+            return;
+        };
+        runtime.spawn(async move {
+            for release in releases {
+                if let Err(error) = session.inject_input(release).await {
+                    eprintln!("[bounded-cu] cancellation safety release failed: {error}");
+                }
+            }
+            drop(display_access);
+        });
+    }
 }
 
 #[async_trait]
@@ -40,9 +110,23 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
         let mut results = Vec::with_capacity(actions.len());
         let mut screenshot = None;
         for action in actions {
+            self.validate_proof_session_liveness().await?;
             validate_resource_binding(&self.params, &self.bus).await?;
+            self.pending_safety_releases = bounded_action_safety_releases(
+                action,
+                self.proof_session.resolution(),
+            )
+            .map_err(|error| {
+                BoundedCuTaskError::new("bounded-cu-input-safety-plan-invalid", error, false)
+            })?;
             let mut outcome = execute_actions_with_exclusive_access(
-                &self.display_access,
+                self.display_access.as_ref().ok_or_else(|| {
+                    BoundedCuTaskError::new(
+                        "bounded-cu-exclusive-display-access-missing",
+                        "bounded executor lost exclusive virtual-display access",
+                        false,
+                    )
+                })?,
                 std::slice::from_ref(action),
                 self.target,
                 self.backend,
@@ -67,6 +151,8 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
             screenshot = Some(action_screenshot);
             results.push(action_result);
             validate_resource_binding(&self.params, &self.bus).await?;
+            self.validate_proof_session_liveness().await?;
+            self.pending_safety_releases.clear();
         }
         let screenshot = screenshot.ok_or_else(|| {
             BoundedCuTaskError::new(
@@ -201,6 +287,13 @@ impl IntendantServer {
                 false,
             )
         })?;
+        if !proof_session.capture_bridge_running().await {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-capture-session-unavailable",
+                "bound display capture was not live before proof automation",
+                false,
+            ));
+        }
         proof_session
             .seal_browser_interactive_for_automation(
                 "bounded proof automation acquired exclusive display control",
@@ -236,10 +329,14 @@ impl IntendantServer {
             session_registry,
             params: params.clone(),
             bus: self.bus.clone(),
-            display_access,
+            display_access: Some(display_access),
+            proof_session,
+            pending_safety_releases: Vec::new(),
         };
         let task_result = execute_bounded_cu_task(provider.as_ref(), &mut executor, request).await;
+        let safety_release = executor.release_pending_input_edges().await;
         let final_binding = validate_resource_binding(&params, &self.bus).await;
+        let final_session_liveness = executor.validate_proof_session_liveness().await;
         let cleanup = scratch.close().map_err(|error| {
             BoundedCuTaskError::new(
                 "bounded-cu-private-scratch-cleanup-failed",
@@ -247,35 +344,66 @@ impl IntendantServer {
                 false,
             )
         });
-        match (task_result, final_binding, cleanup) {
-            (Ok(receipt), Ok(()), Ok(())) => Ok(receipt),
-            (Err(error), Ok(()), Ok(())) => Err(error),
-            (Ok(_), Err(error), Ok(())) | (Ok(_), Ok(()), Err(error)) => Err(error),
-            (Err(task), Err(binding), Ok(())) => Err(BoundedCuTaskError::new(
-                "bounded-cu-task-and-binding-failed",
-                format!("{}; additionally: {}", task.message, binding.message),
-                false,
-            )),
-            (Err(task), Ok(()), Err(cleanup)) => Err(BoundedCuTaskError::new(
-                "bounded-cu-task-and-cleanup-failed",
-                format!("{}; additionally: {}", task.message, cleanup.message),
-                false,
-            )),
-            (Ok(_), Err(binding), Err(cleanup)) => Err(BoundedCuTaskError::new(
-                "bounded-cu-binding-and-cleanup-failed",
-                format!("{}; additionally: {}", binding.message, cleanup.message),
-                false,
-            )),
-            (Err(task), Err(binding), Err(cleanup)) => Err(BoundedCuTaskError::new(
-                "bounded-cu-task-binding-and-cleanup-failed",
-                format!(
-                    "{}; additionally: {}; additionally: {}",
-                    task.message, binding.message, cleanup.message
-                ),
-                false,
-            )),
+        let result = finish_bounded_task(
+            task_result,
+            safety_release,
+            final_binding,
+            final_session_liveness,
+            cleanup,
+        );
+        if params.mode == crate::bounded_cu_task::BoundedCuTaskMode::Stage {
+            if let Ok(receipt) = result.as_ref() {
+                remember_issued_stage_receipt(receipt)?;
+            }
+        }
+        result
+    }
+}
+
+fn finish_bounded_task(
+    task: Result<crate::bounded_cu_task::BoundedCuTaskReceipt, BoundedCuTaskError>,
+    safety_release: Result<(), BoundedCuTaskError>,
+    final_binding: Result<(), BoundedCuTaskError>,
+    final_session_liveness: Result<(), BoundedCuTaskError>,
+    cleanup: Result<(), BoundedCuTaskError>,
+) -> Result<crate::bounded_cu_task::BoundedCuTaskReceipt, BoundedCuTaskError> {
+    let mut receipt = None;
+    let mut errors = Vec::new();
+    match task {
+        Ok(value) => receipt = Some(value),
+        Err(error) => errors.push(error),
+    }
+    for result in [
+        safety_release,
+        final_binding,
+        final_session_liveness,
+        cleanup,
+    ] {
+        if let Err(error) = result {
+            errors.push(error);
         }
     }
+    if errors.is_empty() {
+        return receipt.ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-receipt-missing",
+                "bounded task completed without a receipt",
+                false,
+            )
+        });
+    }
+    if errors.len() == 1 {
+        return Err(errors.remove(0));
+    }
+    Err(BoundedCuTaskError::new(
+        "bounded-cu-task-finalization-failed",
+        errors
+            .into_iter()
+            .map(|error| error.message)
+            .collect::<Vec<_>>()
+            .join("; additionally: "),
+        false,
+    ))
 }
 
 fn require_owner_surface(caller: ToolCallerTrust) -> Result<(), BoundedCuTaskError> {
@@ -382,8 +510,7 @@ fn validate_private_scratch(path: &std::path::Path) -> Result<(), BoundedCuTaskE
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt as _;
-        // SAFETY: `geteuid(2)` takes no arguments and cannot fail.
-        let effective_uid = unsafe { libc::geteuid() };
+        let effective_uid = intendant_platform::platform::unix_effective_uid();
         if metadata.mode() & 0o7777 != 0o700 || metadata.uid() != effective_uid {
             return Err(BoundedCuTaskError::new(
                 "bounded-cu-private-scratch-unsafe",

--- a/src/bin/caller/mcp/tools_bounded_cu.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu.rs
@@ -21,6 +21,8 @@ use crate::conversation::ImageData;
 
 const SCOUT_CDN_LEASE_KIND: &str = "scout_cdn_capture";
 
+type NativeActionJoinHandle = tokio::task::JoinHandle<(crate::computer_use::CuBatchOutcome, u64)>;
+
 struct NativeBoundedCuExecutor {
     target: DisplayTarget,
     backend: DisplayBackend,
@@ -34,6 +36,7 @@ struct NativeBoundedCuExecutor {
     scratch_guard: std::sync::Arc<tempfile::TempDir>,
     initial_frame_not_before: Option<std::time::Instant>,
     pending_safety_releases: Vec<crate::display::InputEvent>,
+    in_flight_action: Option<NativeActionJoinHandle>,
 }
 
 impl NativeBoundedCuExecutor {
@@ -49,12 +52,20 @@ impl NativeBoundedCuExecutor {
         }
     }
 
+    /// Wait for a detached native operation before issuing any fallback input
+    /// releases. The handle remains stored on `self` while it is awaited, so
+    /// cancellation of this cleanup future leaves Drop able to resume the same
+    /// ordering boundary.
     async fn release_pending_input_edges(&mut self) -> Result<(), BoundedCuTaskError> {
+        let in_flight_error = self.await_in_flight_native_action().await.err();
         // Keep the authoritative list on `self` until every release returns.
         // If this cleanup future is itself cancelled, Drop can retry the full
         // idempotent release set while retaining exclusive display access.
         let releases = self.pending_safety_releases.clone();
         let mut errors = Vec::new();
+        if let Some(error) = in_flight_error.as_ref() {
+            errors.push(error.message.clone());
+        }
         for release in releases {
             if let Err(error) = self.proof_session.inject_input(release).await {
                 errors.push(error.to_string());
@@ -63,16 +74,44 @@ impl NativeBoundedCuExecutor {
         if errors.is_empty() {
             self.pending_safety_releases.clear();
             Ok(())
+        } else if errors.len() == 1 && in_flight_error.is_some() {
+            self.pending_safety_releases.clear();
+            Err(in_flight_error.expect("checked above"))
         } else {
             Err(BoundedCuTaskError::new(
                 "bounded-cu-input-safety-release-failed",
                 format!(
-                    "could not release every possibly-held direct input edge: {}",
+                    "could not complete the in-flight action and release every possibly-held direct input edge: {}",
                     errors.join("; ")
                 ),
                 false,
             ))
         }
+    }
+
+    async fn await_in_flight_native_action(
+        &mut self,
+    ) -> Result<Option<crate::computer_use::CuBatchOutcome>, BoundedCuTaskError> {
+        if self.in_flight_action.is_none() {
+            return Ok(None);
+        }
+        let joined = {
+            let execution = self
+                .in_flight_action
+                .as_mut()
+                .expect("checked in-flight native action above");
+            execution.await
+        };
+        self.in_flight_action.take();
+        let (outcome, action_counter) = joined.map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-native-action-task-failed",
+                format!("native computer-use action task failed: {error}"),
+                false,
+            )
+        })?;
+        self.action_counter = action_counter;
+        Ok(Some(outcome))
     }
 
     async fn require_post_seal_initial_frame(&mut self) -> Result<(), BoundedCuTaskError> {
@@ -117,6 +156,13 @@ impl NativeBoundedCuExecutor {
                 false,
             )
         })?;
+        if self.in_flight_action.is_some() {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-native-action-overlap",
+                "a prior native computer-use action was still in flight",
+                false,
+            ));
+        }
         let action = action.clone();
         let target = self.target;
         let backend = self.backend;
@@ -124,7 +170,7 @@ impl NativeBoundedCuExecutor {
         let scratch_guard = std::sync::Arc::clone(&self.scratch_guard);
         let session_registry = self.session_registry.clone();
         let mut action_counter = self.action_counter;
-        let execution = tokio::spawn(async move {
+        self.in_flight_action = Some(tokio::spawn(async move {
             let _scratch_guard = scratch_guard;
             let outcome = execute_actions_with_exclusive_access(
                 &display_access,
@@ -141,36 +187,41 @@ impl NativeBoundedCuExecutor {
             )
             .await;
             (outcome, action_counter)
-        });
-        let (outcome, action_counter) = execution.await.map_err(|error| {
+        }));
+        self.await_in_flight_native_action().await?.ok_or_else(|| {
             BoundedCuTaskError::new(
-                "bounded-cu-native-action-task-failed",
-                format!("native computer-use action task failed: {error}"),
+                "bounded-cu-native-action-result-missing",
+                "native computer-use action completed without an outcome",
                 false,
             )
-        })?;
-        self.action_counter = action_counter;
-        Ok(outcome)
+        })
     }
 }
 
 impl Drop for NativeBoundedCuExecutor {
     fn drop(&mut self) {
-        if self.pending_safety_releases.is_empty() {
+        let in_flight_action = self.in_flight_action.take();
+        let releases = std::mem::take(&mut self.pending_safety_releases);
+        if in_flight_action.is_none() && releases.is_empty() {
             return;
         }
-        let releases = std::mem::take(&mut self.pending_safety_releases);
         let Some(display_access) = self.display_access.take() else {
             return;
         };
         let session = std::sync::Arc::clone(&self.proof_session);
         let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            eprintln!(
-                "[bounded-cu] no Tokio runtime was available for cancellation safety releases"
-            );
+            eprintln!("[bounded-cu] no Tokio runtime was available for cancellation cleanup");
+            // Fail closed during runtime teardown: do not make the display
+            // available while an in-flight native operation or possibly-held input edge cannot be completed safely.
+            std::mem::forget(display_access);
             return;
         };
         runtime.spawn(async move {
+            if let Some(execution) = in_flight_action {
+                if let Err(error) = execution.await {
+                    eprintln!("[bounded-cu] cancelled native action task failed: {error}");
+                }
+            }
             for release in releases {
                 if let Err(error) = session.inject_input(release).await {
                     eprintln!("[bounded-cu] cancellation safety release failed: {error}");
@@ -412,6 +463,7 @@ impl IntendantServer {
             scratch_guard: std::sync::Arc::clone(&scratch),
             initial_frame_not_before: Some(initial_frame_not_before),
             pending_safety_releases: Vec::new(),
+            in_flight_action: None,
         };
         let task_result =
             execute_bounded_cu_task_until(provider.as_ref(), &mut executor, request, deadline)
@@ -849,5 +901,158 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    struct OrderedReleaseBackend {
+        events: std::sync::Arc<tokio::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::display::DisplayBackend for OrderedReleaseBackend {
+        async fn start_capture(
+            &self,
+            _fps: u32,
+        ) -> Result<tokio::sync::mpsc::Receiver<crate::display::Frame>, crate::error::CallerError>
+        {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+
+        async fn stop_capture(&self) {}
+
+        async fn inject_input(
+            &self,
+            _event: crate::display::InputEvent,
+        ) -> Result<(), crate::error::CallerError> {
+            self.events.lock().await.push("release");
+            Ok(())
+        }
+
+        fn resolution(&self) -> (u32, u32) {
+            (1280, 720)
+        }
+
+        fn kind(&self) -> &'static str {
+            "ordered-release-test"
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_cleanup_waits_for_detached_native_action_before_releasing() {
+        const DISPLAY_ID: u32 = 424_244;
+        let events = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let action_gate = std::sync::Arc::new(tokio::sync::Notify::new());
+        let action_events = std::sync::Arc::clone(&events);
+        let task_gate = std::sync::Arc::clone(&action_gate);
+        let in_flight_action: NativeActionJoinHandle = tokio::spawn(async move {
+            task_gate.notified().await;
+            action_events.lock().await.push("action-finished");
+            panic!("synthetic detached native action failure");
+        });
+
+        let backend = std::sync::Arc::new(OrderedReleaseBackend {
+            events: std::sync::Arc::clone(&events),
+        });
+        let proof_session =
+            std::sync::Arc::new(crate::display::DisplaySession::new(DISPLAY_ID, backend));
+        let scratch_guard = std::sync::Arc::new(tempfile::tempdir().unwrap());
+        let display_access =
+            crate::computer_use::acquire_virtual_display_exclusive(DISPLAY_ID).await;
+        let mut executor = NativeBoundedCuExecutor {
+            target: DisplayTarget::Virtual { id: DISPLAY_ID },
+            backend: DisplayBackend::X11,
+            display_access: Some(display_access),
+            proof_session,
+            bus: crate::event::EventBus::new(),
+            params: params(),
+            session_registry: None,
+            action_counter: 0,
+            scratch_dir: scratch_guard.path().to_path_buf(),
+            scratch_guard,
+            initial_frame_not_before: None,
+            pending_safety_releases: vec![crate::display::InputEvent::KeyUp {
+                code: "KeyA".to_string(),
+                key: "a".to_string(),
+                shift: false,
+                ctrl: false,
+                alt: false,
+                meta: false,
+            }],
+            in_flight_action: Some(in_flight_action),
+        };
+
+        let mut cleanup = Box::pin(executor.release_pending_input_edges());
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), cleanup.as_mut(),)
+                .await
+                .is_err()
+        );
+        assert!(events.lock().await.is_empty());
+
+        action_gate.notify_one();
+        let error = cleanup.await.unwrap_err();
+        assert_eq!(error.code, "bounded-cu-native-action-task-failed");
+        assert_eq!(
+            events.lock().await.as_slice(),
+            &["action-finished", "release"]
+        );
+        assert!(executor.pending_safety_releases.is_empty());
+        assert!(executor.in_flight_action.is_none());
+    }
+
+    #[tokio::test]
+    async fn drop_retains_display_fence_for_in_flight_action_without_input_releases() {
+        const DISPLAY_ID: u32 = 424_245;
+        let events = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let action_gate = std::sync::Arc::new(tokio::sync::Notify::new());
+        let action_events = std::sync::Arc::clone(&events);
+        let task_gate = std::sync::Arc::clone(&action_gate);
+        let in_flight_action: NativeActionJoinHandle = tokio::spawn(async move {
+            task_gate.notified().await;
+            action_events.lock().await.push("action-finished");
+            panic!("synthetic detached native action failure");
+        });
+
+        let backend = std::sync::Arc::new(OrderedReleaseBackend {
+            events: std::sync::Arc::clone(&events),
+        });
+        let proof_session =
+            std::sync::Arc::new(crate::display::DisplaySession::new(DISPLAY_ID, backend));
+        let scratch_guard = std::sync::Arc::new(tempfile::tempdir().unwrap());
+        let display_access =
+            crate::computer_use::acquire_virtual_display_exclusive(DISPLAY_ID).await;
+        let executor = NativeBoundedCuExecutor {
+            target: DisplayTarget::Virtual { id: DISPLAY_ID },
+            backend: DisplayBackend::X11,
+            display_access: Some(display_access),
+            proof_session,
+            bus: crate::event::EventBus::new(),
+            params: params(),
+            session_registry: None,
+            action_counter: 0,
+            scratch_dir: scratch_guard.path().to_path_buf(),
+            scratch_guard,
+            initial_frame_not_before: None,
+            pending_safety_releases: Vec::new(),
+            in_flight_action: Some(in_flight_action),
+        };
+
+        drop(executor);
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(20),
+            crate::computer_use::acquire_virtual_display_shared(DISPLAY_ID),
+        )
+        .await
+        .is_err());
+
+        action_gate.notify_one();
+        let shared = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            crate::computer_use::acquire_virtual_display_shared(DISPLAY_ID),
+        )
+        .await
+        .expect("detached action completion must release the display fence");
+        assert_eq!(events.lock().await.as_slice(), &["action-finished"]);
+        drop(shared);
     }
 }

--- a/src/bin/caller/mcp/tools_bounded_cu.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu.rs
@@ -23,6 +23,25 @@ const SCOUT_CDN_LEASE_KIND: &str = "scout_cdn_capture";
 
 type NativeActionJoinHandle = tokio::task::JoinHandle<(crate::computer_use::CuBatchOutcome, u64)>;
 
+/// Run a cancellation-sensitive display operation in an owned task that retains
+/// the exclusive display fence. Dropping the caller's await detaches the owned
+/// task, so the fence is not released until the already-started operation has
+/// actually completed.
+async fn run_with_display_fence<T, F>(
+    display_access: VirtualDisplayExclusiveAccess,
+    operation: F,
+) -> Result<T, tokio::task::JoinError>
+where
+    T: Send + 'static,
+    F: std::future::Future<Output = T> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let _display_access = display_access;
+        operation.await
+    })
+    .await
+}
+
 struct NativeBoundedCuExecutor {
     target: DisplayTarget,
     backend: DisplayBackend,
@@ -422,18 +441,35 @@ impl IntendantServer {
                 false,
             ));
         }
-        proof_session
-            .seal_browser_interactive_for_automation(
-                "bounded proof automation acquired exclusive display control",
-            )
-            .await
-            .map_err(|error| {
-                BoundedCuTaskError::new(
-                    "bounded-cu-browser-interactive-seal-failed",
-                    error.to_string(),
-                    false,
+        // Sealing waits for the browser input pump and every admitted clipboard
+        // mutation. The outer task deadline may cancel this await after those
+        // operations have started, so run it in an owned task that keeps a clone
+        // of the exclusive display fence until the seal has actually completed.
+        // This mirrors the detached native-action boundary below and prevents a
+        // timed-out proof request from overlapping lingering browser input.
+        let sealing_session = std::sync::Arc::clone(&proof_session);
+        run_with_display_fence(display_access.clone(), async move {
+            sealing_session
+                .seal_browser_interactive_for_automation(
+                    "bounded proof automation acquired exclusive display control",
                 )
-            })?;
+                .await
+        })
+        .await
+        .map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-browser-interactive-seal-task-failed",
+                format!("browser interactive sealing task failed: {error}"),
+                false,
+            )
+        })?
+        .map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-browser-interactive-seal-failed",
+                error.to_string(),
+                false,
+            )
+        })?;
         let initial_frame_not_before = std::time::Instant::now();
         let dimensions = crate::computer_use::target_pixel_size(target, &session_registry).await;
         if dimensions.0 == 0 || dimensions.1 == 0 {
@@ -881,6 +917,38 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_seal_waiter_retains_display_fence_until_operation_finishes() {
+        const DISPLAY_ID: u32 = 424_246;
+        let exclusive = crate::computer_use::acquire_virtual_display_exclusive(DISPLAY_ID).await;
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let waiter = tokio::spawn(run_with_display_fence(exclusive, async move {
+            let _ = started_tx.send(());
+            let _ = finish_rx.await;
+        }));
+        started_rx.await.unwrap();
+        waiter.abort();
+        assert!(waiter.await.unwrap_err().is_cancelled());
+
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(20),
+            crate::computer_use::acquire_virtual_display_shared(DISPLAY_ID),
+        )
+        .await
+        .is_err());
+
+        finish_tx.send(()).unwrap();
+        let shared = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            crate::computer_use::acquire_virtual_display_shared(DISPLAY_ID),
+        )
+        .await
+        .expect("the owned sealing operation must eventually release the display fence");
+        drop(shared);
     }
 
     #[tokio::test]

--- a/src/bin/caller/mcp/tools_bounded_cu.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu.rs
@@ -5,7 +5,7 @@ use super::*;
 use async_trait::async_trait;
 
 use crate::bounded_cu_task::{
-    remember_issued_stage_receipt, run_bounded_cu_task as execute_bounded_cu_task,
+    remember_issued_stage_receipt, run_bounded_cu_task_until as execute_bounded_cu_task_until,
     validate_bounded_cu_task_request, BoundedCuActionExecutor, BoundedCuActionOutcome,
     BoundedCuTaskError, BoundedCuTaskRequest,
 };
@@ -31,6 +31,8 @@ struct NativeBoundedCuExecutor {
     bus: crate::event::EventBus,
     display_access: Option<VirtualDisplayExclusiveAccess>,
     proof_session: std::sync::Arc<crate::display::DisplaySession>,
+    scratch_guard: std::sync::Arc<tempfile::TempDir>,
+    initial_frame_not_before: Option<std::time::Instant>,
     pending_safety_releases: Vec<crate::display::InputEvent>,
 }
 
@@ -72,6 +74,84 @@ impl NativeBoundedCuExecutor {
             ))
         }
     }
+
+    async fn require_post_seal_initial_frame(&mut self) -> Result<(), BoundedCuTaskError> {
+        let Some(not_before) = self.initial_frame_not_before else {
+            return Ok(());
+        };
+        let frame = self
+            .proof_session
+            .fresh_frame(not_before, std::time::Duration::from_secs(1))
+            .await
+            .map_err(|error| {
+                BoundedCuTaskError::new(
+                    "bounded-cu-post-seal-frame-unavailable",
+                    format!("could not capture a frame after browser input sealing: {error}"),
+                    false,
+                )
+            })?;
+        if frame.timestamp < not_before {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-post-seal-frame-stale",
+                "capture did not produce a frame after browser input sealing",
+                false,
+            ));
+        }
+        self.initial_frame_not_before = None;
+        Ok(())
+    }
+
+    /// Execute through an owned task that retains both the exclusive display
+    /// token and scratch lifetime. Tokio cannot abort an already-started X11
+    /// `spawn_blocking` operation; if the request deadline cancels this await,
+    /// the detached task therefore keeps other input excluded until the
+    /// bounded OS operation and its observation have actually completed.
+    async fn execute_native_action(
+        &mut self,
+        action: &CuAction,
+    ) -> Result<crate::computer_use::CuBatchOutcome, BoundedCuTaskError> {
+        let display_access = self.display_access.as_ref().cloned().ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-exclusive-display-access-missing",
+                "bounded executor lost exclusive virtual-display access",
+                false,
+            )
+        })?;
+        let action = action.clone();
+        let target = self.target;
+        let backend = self.backend;
+        let scratch_dir = self.scratch_dir.clone();
+        let scratch_guard = std::sync::Arc::clone(&self.scratch_guard);
+        let session_registry = self.session_registry.clone();
+        let mut action_counter = self.action_counter;
+        let execution = tokio::spawn(async move {
+            let _scratch_guard = scratch_guard;
+            let outcome = execute_actions_with_exclusive_access(
+                &display_access,
+                std::slice::from_ref(&action),
+                target,
+                backend,
+                &scratch_dir,
+                &mut action_counter,
+                &session_registry,
+                None,
+                false,
+                None,
+                CuExecOptions::default(),
+            )
+            .await;
+            (outcome, action_counter)
+        });
+        let (outcome, action_counter) = execution.await.map_err(|error| {
+            BoundedCuTaskError::new(
+                "bounded-cu-native-action-task-failed",
+                format!("native computer-use action task failed: {error}"),
+                false,
+            )
+        })?;
+        self.action_counter = action_counter;
+        Ok(outcome)
+    }
 }
 
 impl Drop for NativeBoundedCuExecutor {
@@ -110,6 +190,16 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
         let mut results = Vec::with_capacity(actions.len());
         let mut screenshot = None;
         for action in actions {
+            if self.initial_frame_not_before.is_some() {
+                if !matches!(action, CuAction::Screenshot) {
+                    return Err(BoundedCuTaskError::new(
+                        "bounded-cu-initial-frame-order-invalid",
+                        "bounded proof task attempted input before its post-seal initial frame",
+                        false,
+                    ));
+                }
+                self.require_post_seal_initial_frame().await?;
+            }
             self.validate_proof_session_liveness().await?;
             validate_resource_binding(&self.params, &self.bus).await?;
             self.pending_safety_releases = bounded_action_safety_releases(
@@ -119,26 +209,7 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
             .map_err(|error| {
                 BoundedCuTaskError::new("bounded-cu-input-safety-plan-invalid", error, false)
             })?;
-            let mut outcome = execute_actions_with_exclusive_access(
-                self.display_access.as_ref().ok_or_else(|| {
-                    BoundedCuTaskError::new(
-                        "bounded-cu-exclusive-display-access-missing",
-                        "bounded executor lost exclusive virtual-display access",
-                        false,
-                    )
-                })?,
-                std::slice::from_ref(action),
-                self.target,
-                self.backend,
-                &self.scratch_dir,
-                &mut self.action_counter,
-                &self.session_registry,
-                None,
-                false,
-                None,
-                CuExecOptions::default(),
-            )
-            .await;
+            let mut outcome = self.execute_native_action(action).await?;
             let (action_result, action_screenshot) =
                 split_action_and_observation(action, std::mem::take(&mut outcome.results))?;
             if action_result.status == CuActionStatus::Failed {
@@ -232,18 +303,24 @@ impl IntendantServer {
         params: RunBoundedCuTaskParams,
         caller: ToolCallerTrust,
     ) -> String {
+        let mode = params.mode;
+        let deadline = tokio::time::Instant::now() + mode.timeout();
         if let Err(error) = require_owner_surface(caller) {
             return bounded_error_json(error);
         }
-        match self.run_bounded_cu_task_inner(params).await {
-            Ok(receipt) => serde_json::json!({ "ok": true, "receipt": receipt }).to_string(),
-            Err(error) => bounded_error_json(error),
+        match tokio::time::timeout_at(deadline, self.run_bounded_cu_task_inner(params, deadline))
+            .await
+        {
+            Ok(Ok(receipt)) => serde_json::json!({ "ok": true, "receipt": receipt }).to_string(),
+            Ok(Err(error)) => bounded_error_json(error),
+            Err(_) => bounded_error_json(mode.deadline_error()),
         }
     }
 
     async fn run_bounded_cu_task_inner(
         &self,
         params: RunBoundedCuTaskParams,
+        deadline: tokio::time::Instant,
     ) -> Result<crate::bounded_cu_task::BoundedCuTaskReceipt, BoundedCuTaskError> {
         let request = BoundedCuTaskRequest {
             mode: params.mode,
@@ -306,6 +383,7 @@ impl IntendantServer {
                     false,
                 )
             })?;
+        let initial_frame_not_before = std::time::Instant::now();
         let dimensions = crate::computer_use::target_pixel_size(target, &session_registry).await;
         if dimensions.0 == 0 || dimensions.1 == 0 {
             return Err(BoundedCuTaskError::new(
@@ -319,7 +397,7 @@ impl IntendantServer {
                 BoundedCuTaskError::new("bounded-cu-provider-unavailable", error.to_string(), true)
             })?;
         provider.set_cu_display(dimensions);
-        let scratch = create_private_scratch()?;
+        let scratch = std::sync::Arc::new(create_private_scratch()?);
         validate_private_scratch(scratch.path())?;
         let mut executor = NativeBoundedCuExecutor {
             target,
@@ -331,19 +409,33 @@ impl IntendantServer {
             bus: self.bus.clone(),
             display_access: Some(display_access),
             proof_session,
+            scratch_guard: std::sync::Arc::clone(&scratch),
+            initial_frame_not_before: Some(initial_frame_not_before),
             pending_safety_releases: Vec::new(),
         };
-        let task_result = execute_bounded_cu_task(provider.as_ref(), &mut executor, request).await;
+        let task_result =
+            execute_bounded_cu_task_until(provider.as_ref(), &mut executor, request, deadline)
+                .await;
         let safety_release = executor.release_pending_input_edges().await;
         let final_binding = validate_resource_binding(&params, &self.bus).await;
         let final_session_liveness = executor.validate_proof_session_liveness().await;
-        let cleanup = scratch.close().map_err(|error| {
-            BoundedCuTaskError::new(
-                "bounded-cu-private-scratch-cleanup-failed",
-                format!("cannot remove private CU scratch directory: {error}"),
-                false,
-            )
-        });
+        drop(executor);
+        let cleanup = match std::sync::Arc::try_unwrap(scratch) {
+            Ok(scratch) => scratch.close().map_err(|error| {
+                BoundedCuTaskError::new(
+                    "bounded-cu-private-scratch-cleanup-failed",
+                    format!("cannot remove private CU scratch directory: {error}"),
+                    false,
+                )
+            }),
+            // A request deadline can detach one already-started platform
+            // operation. Its owned Arc removes the scratch directory when it
+            // finishes; the same task retains exclusive display access.
+            Err(scratch) => {
+                drop(scratch);
+                Ok(())
+            }
+        };
         let result = finish_bounded_task(
             task_result,
             safety_release,
@@ -436,7 +528,12 @@ async fn validate_resource_binding(
     }
     let workspaces = crate::browser_workspace::list_workspaces(bus).await;
     let workspace = exclusive_workspace_on_display(&workspaces, params)?;
-    validate_workspace(workspace, params)
+    validate_workspace(workspace, params)?;
+    crate::browser_workspace::verify_live_workspace(workspace)
+        .await
+        .map_err(|error| {
+            BoundedCuTaskError::new("bounded-cu-workspace-runtime-unavailable", error, false)
+        })
 }
 
 fn exclusive_workspace_on_display<'a>(
@@ -479,7 +576,9 @@ fn validate_workspace(
         || workspace.display_target.as_deref() != Some(params.display_target.as_str())
         || workspace.owner_session_id.as_deref() != Some(params.attempt_id.as_str())
         || workspace.process_id.is_none()
+        || workspace.debugging_port.is_none()
         || workspace.cdp_http_url.is_none()
+        || workspace.cdp_ws_url.is_none()
         || workspace.active_target_id.is_none()
         || !exact_lease
     {
@@ -727,6 +826,26 @@ mod tests {
         tokio::time::timeout(
             std::time::Duration::from_secs(1),
             crate::computer_use::acquire_virtual_display_shared(424_242),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn retained_exclusive_access_outlives_the_request_owner() {
+        let exclusive = crate::computer_use::acquire_virtual_display_exclusive(424_243).await;
+        let detached_operation = exclusive.clone();
+        drop(exclusive);
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            crate::computer_use::acquire_virtual_display_shared(424_243),
+        )
+        .await
+        .is_err());
+        drop(detached_operation);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            crate::computer_use::acquire_virtual_display_shared(424_243),
         )
         .await
         .unwrap();

--- a/src/bin/caller/mcp/tools_bounded_cu.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu.rs
@@ -3,8 +3,6 @@
 
 use super::*;
 use async_trait::async_trait;
-use std::collections::HashSet;
-use std::sync::{Mutex, OnceLock};
 
 use crate::bounded_cu_task::{
     run_bounded_cu_task as execute_bounded_cu_task, validate_bounded_cu_task_request,
@@ -14,55 +12,13 @@ use crate::browser_workspace::{
     BrowserWorkspace, BrowserWorkspaceProvider, BrowserWorkspaceStatus,
 };
 use crate::computer_use::{
-    execute_actions, summarize_results_for_model, CuAction, CuActionStatus, CuExecOptions,
-    DisplayBackend, DisplayTarget,
+    execute_actions_with_exclusive_access, summarize_results_for_model, CuAction, CuActionResult,
+    CuActionStatus, CuExecOptions, DisplayBackend, DisplayTarget, ScreenshotData,
+    VirtualDisplayExclusiveAccess,
 };
 use crate::conversation::ImageData;
 
 const SCOUT_CDN_LEASE_KIND: &str = "scout_cdn_capture";
-
-fn active_bounded_displays() -> &'static Mutex<HashSet<(u32, String)>> {
-    static ACTIVE: OnceLock<Mutex<HashSet<(u32, String)>>> = OnceLock::new();
-    ACTIVE.get_or_init(|| Mutex::new(HashSet::new()))
-}
-
-#[derive(Debug)]
-struct BoundedDisplayExecutionLease {
-    display_id: u32,
-    capture_generation: String,
-}
-
-impl BoundedDisplayExecutionLease {
-    fn acquire(display_id: u32, capture_generation: &str) -> Result<Self, BoundedCuTaskError> {
-        let mut active = active_bounded_displays().lock().map_err(|_| {
-            BoundedCuTaskError::new(
-                "bounded-cu-execution-lease-unavailable",
-                "bounded CU execution-lease registry was poisoned",
-                false,
-            )
-        })?;
-        let key = (display_id, capture_generation.to_string());
-        if !active.insert(key) {
-            return Err(BoundedCuTaskError::new(
-                "bounded-cu-execution-already-active",
-                "another bounded CU task already owns this exact display generation",
-                true,
-            ));
-        }
-        Ok(Self {
-            display_id,
-            capture_generation: capture_generation.to_string(),
-        })
-    }
-}
-
-impl Drop for BoundedDisplayExecutionLease {
-    fn drop(&mut self) {
-        if let Ok(mut active) = active_bounded_displays().lock() {
-            active.remove(&(self.display_id, self.capture_generation.clone()));
-        }
-    }
-}
 
 struct NativeBoundedCuExecutor {
     target: DisplayTarget,
@@ -72,6 +28,7 @@ struct NativeBoundedCuExecutor {
     session_registry: Option<crate::display::SharedSessionRegistry>,
     params: RunBoundedCuTaskParams,
     bus: crate::event::EventBus,
+    display_access: VirtualDisplayExclusiveAccess,
 }
 
 #[async_trait]
@@ -84,7 +41,8 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
         let mut screenshot = None;
         for action in actions {
             validate_resource_binding(&self.params, &self.bus).await?;
-            let outcome = execute_actions(
+            let mut outcome = execute_actions_with_exclusive_access(
+                &self.display_access,
                 std::slice::from_ref(action),
                 self.target,
                 self.backend,
@@ -97,21 +55,9 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
                 CuExecOptions::default(),
             )
             .await;
-            if outcome.results.len() != 1 {
-                return Err(BoundedCuTaskError::new(
-                    "bounded-cu-action-cardinality-mismatch",
-                    "native computer use did not return exactly one result for one action",
-                    false,
-                ));
-            }
-            let action_screenshot = outcome.last_screenshot().cloned().ok_or_else(|| {
-                BoundedCuTaskError::new(
-                    "bounded-cu-observation-missing",
-                    "native computer-use action returned no trailing screenshot",
-                    false,
-                )
-            })?;
-            if outcome.results[0].status == CuActionStatus::Failed {
+            let (action_result, action_screenshot) =
+                split_action_and_observation(action, std::mem::take(&mut outcome.results))?;
+            if action_result.status == CuActionStatus::Failed {
                 return Err(BoundedCuTaskError::new(
                     "bounded-cu-action-failed",
                     "native computer-use action failed; later actions were not executed",
@@ -119,7 +65,7 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
                 ));
             }
             screenshot = Some(action_screenshot);
-            results.extend(outcome.results);
+            results.push(action_result);
             validate_resource_binding(&self.params, &self.bus).await?;
         }
         let screenshot = screenshot.ok_or_else(|| {
@@ -141,6 +87,46 @@ impl BoundedCuActionExecutor for NativeBoundedCuExecutor {
                 .collect::<Vec<CuActionStatus>>(),
         })
     }
+}
+
+fn split_action_and_observation(
+    action: &CuAction,
+    mut results: Vec<CuActionResult>,
+) -> Result<(CuActionResult, ScreenshotData), BoundedCuTaskError> {
+    let captures_itself = matches!(action, CuAction::Screenshot | CuAction::Zoom { .. });
+    let expected_results = if captures_itself { 1 } else { 2 };
+    if results.len() != expected_results {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-action-cardinality-mismatch",
+            format!(
+                "native computer use returned {} results; expected {expected_results} for one action plus its policy-driven observation",
+                results.len()
+            ),
+            false,
+        ));
+    }
+    let mut action_result = results.remove(0);
+    let observation_result = if captures_itself { None } else { results.pop() };
+    let screenshot = match observation_result {
+        Some(result) if result.status == CuActionStatus::Failed => {
+            return Err(BoundedCuTaskError::new(
+                "bounded-cu-observation-failed",
+                "native computer-use trailing observation failed",
+                false,
+            ));
+        }
+        Some(mut result) => result.screenshot.take(),
+        None => action_result.screenshot.take(),
+    }
+    .ok_or_else(|| {
+        BoundedCuTaskError::new(
+            "bounded-cu-observation-missing",
+            "native computer-use action returned no trailing screenshot",
+            false,
+        )
+    })?;
+    action_result.screenshot = None;
+    Ok((action_result, screenshot))
 }
 
 impl IntendantServer {
@@ -182,14 +168,15 @@ impl IntendantServer {
             capture_generation: params.capture_generation.clone(),
             task: params.task.clone(),
             prior_receipt_id: params.prior_receipt_id.clone(),
-            prior_transcript_event_count: params.prior_transcript_event_count,
-            prior_transcript_sha256: params.prior_transcript_sha256.clone(),
-            observation_sha256: params.observation_sha256.clone(),
+            prior_transcript_event_count: None,
+            prior_transcript_sha256: None,
+            observation_sha256: None,
+            prior_completed_at: None,
         };
         validate_bounded_cu_task_request(&request)?;
+        let display_access =
+            crate::computer_use::acquire_virtual_display_exclusive(params.display_id).await;
         validate_resource_binding(&params, &self.bus).await?;
-        let _execution_lease =
-            BoundedDisplayExecutionLease::acquire(params.display_id, &params.capture_generation)?;
         let (cu_config, session_registry, action_counter) = {
             let state = self.state.read().await;
             (
@@ -203,6 +190,29 @@ impl IntendantServer {
         let target = DisplayTarget::Virtual {
             id: params.display_id,
         };
+        let proof_session = match session_registry.as_ref() {
+            Some(registry) => registry.read().await.get(params.display_id),
+            None => None,
+        }
+        .ok_or_else(|| {
+            BoundedCuTaskError::new(
+                "bounded-cu-display-session-missing",
+                "bound virtual display had no agent-visible capture/input session",
+                false,
+            )
+        })?;
+        proof_session
+            .seal_browser_interactive_for_automation(
+                "bounded proof automation acquired exclusive display control",
+            )
+            .await
+            .map_err(|error| {
+                BoundedCuTaskError::new(
+                    "bounded-cu-browser-interactive-seal-failed",
+                    error.to_string(),
+                    false,
+                )
+            })?;
         let dimensions = crate::computer_use::target_pixel_size(target, &session_registry).await;
         if dimensions.0 == 0 || dimensions.1 == 0 {
             return Err(BoundedCuTaskError::new(
@@ -226,6 +236,7 @@ impl IntendantServer {
             session_registry,
             params: params.clone(),
             bus: self.bus.clone(),
+            display_access,
         };
         let task_result = execute_bounded_cu_task(provider.as_ref(), &mut executor, request).await;
         let final_binding = validate_resource_binding(&params, &self.bus).await;
@@ -296,17 +307,35 @@ async fn validate_resource_binding(
         ));
     }
     let workspaces = crate::browser_workspace::list_workspaces(bus).await;
-    let workspace = workspaces
-        .iter()
-        .find(|workspace| workspace.id == params.workspace_id)
-        .ok_or_else(|| {
-            BoundedCuTaskError::new(
-                "bounded-cu-workspace-missing",
-                "exact browser workspace was not found",
-                false,
-            )
-        })?;
+    let workspace = exclusive_workspace_on_display(&workspaces, params)?;
     validate_workspace(workspace, params)
+}
+
+fn exclusive_workspace_on_display<'a>(
+    workspaces: &'a [BrowserWorkspace],
+    params: &RunBoundedCuTaskParams,
+) -> Result<&'a BrowserWorkspace, BoundedCuTaskError> {
+    let mut active_on_display = workspaces.iter().filter(|workspace| {
+        matches!(
+            workspace.status,
+            BrowserWorkspaceStatus::Starting | BrowserWorkspaceStatus::Ready
+        ) && workspace.display_target.as_deref() == Some(params.display_target.as_str())
+    });
+    let workspace = active_on_display.next().ok_or_else(|| {
+        BoundedCuTaskError::new(
+            "bounded-cu-workspace-missing",
+            "no eligible browser workspace was bound to the exact display",
+            false,
+        )
+    })?;
+    if active_on_display.next().is_some() || workspace.id != params.workspace_id {
+        return Err(BoundedCuTaskError::new(
+            "bounded-cu-display-workspace-not-exclusive",
+            "the proof display was not exclusively bound to the selected browser workspace",
+            false,
+        ));
+    }
+    Ok(workspace)
 }
 
 fn validate_workspace(
@@ -399,6 +428,24 @@ fn bounded_error_json(error: BoundedCuTaskError) -> String {
 mod tests {
     use super::*;
 
+    fn screenshot_data(name: &str) -> ScreenshotData {
+        ScreenshotData {
+            path: std::path::PathBuf::from(name),
+            base64_png: "iVBORw0KGgo=".to_string(),
+            width: 1,
+            height: 1,
+        }
+    }
+
+    fn action_result(status: CuActionStatus, screenshot: Option<ScreenshotData>) -> CuActionResult {
+        CuActionResult {
+            status,
+            screenshot,
+            error: None,
+            detail: None,
+        }
+    }
+
     fn params() -> RunBoundedCuTaskParams {
         RunBoundedCuTaskParams {
             mode: crate::bounded_cu_task::BoundedCuTaskMode::Stage,
@@ -409,9 +456,6 @@ mod tests {
             capture_generation: "vdcg-1".to_string(),
             task: "stage".to_string(),
             prior_receipt_id: None,
-            prior_transcript_event_count: None,
-            prior_transcript_sha256: None,
-            observation_sha256: None,
         }
     }
 
@@ -461,6 +505,72 @@ mod tests {
     }
 
     #[test]
+    fn proof_display_rejects_every_second_active_browser_workspace() {
+        let params = params();
+        let selected = workspace();
+        assert_eq!(
+            exclusive_workspace_on_display(std::slice::from_ref(&selected), &params)
+                .unwrap()
+                .id,
+            selected.id
+        );
+
+        let mut second = selected.clone();
+        second.id = "bw-2".to_string();
+        second.provider = BrowserWorkspaceProvider::SystemCdp;
+        let error = exclusive_workspace_on_display(&[selected, second], &params).unwrap_err();
+        assert_eq!(error.code, "bounded-cu-display-workspace-not-exclusive");
+    }
+
+    #[test]
+    fn ordinary_action_keeps_one_status_and_uses_the_trailing_observation() {
+        let action = CuAction::Click {
+            x: 1,
+            y: 2,
+            button: Default::default(),
+        };
+        let (result, screenshot) = split_action_and_observation(
+            &action,
+            vec![
+                action_result(
+                    CuActionStatus::Injected,
+                    Some(screenshot_data("convenience-copy.png")),
+                ),
+                action_result(
+                    CuActionStatus::Verified,
+                    Some(screenshot_data("trailing.png")),
+                ),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(result.status, CuActionStatus::Injected);
+        assert!(result.screenshot.is_none());
+        assert_eq!(screenshot.path, std::path::PathBuf::from("trailing.png"));
+    }
+
+    #[test]
+    fn failed_trailing_observation_is_not_masked_by_its_convenience_copy() {
+        let action = CuAction::Wait { ms: 1 };
+        let error = split_action_and_observation(
+            &action,
+            vec![
+                action_result(
+                    CuActionStatus::Verified,
+                    Some(screenshot_data("convenience-copy.png")),
+                ),
+                action_result(
+                    CuActionStatus::Failed,
+                    Some(screenshot_data("failed-trailing.png")),
+                ),
+            ],
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "bounded-cu-observation-failed");
+    }
+
+    #[test]
     fn private_scratch_is_mode_0700() {
         let scratch = create_private_scratch().unwrap();
         validate_private_scratch(scratch.path()).unwrap();
@@ -477,16 +587,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn exact_display_generation_allows_only_one_bounded_task() {
-        let first = BoundedDisplayExecutionLease::acquire(424_242, "vdcg-test-exclusive").unwrap();
-        assert_eq!(
-            BoundedDisplayExecutionLease::acquire(424_242, "vdcg-test-exclusive")
-                .unwrap_err()
-                .code,
-            "bounded-cu-execution-already-active"
-        );
-        drop(first);
-        BoundedDisplayExecutionLease::acquire(424_242, "vdcg-test-exclusive").unwrap();
+    #[tokio::test]
+    async fn bounded_task_excludes_other_access_to_its_virtual_display() {
+        let exclusive = crate::computer_use::acquire_virtual_display_exclusive(424_242).await;
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            crate::computer_use::acquire_virtual_display_shared(424_242),
+        )
+        .await
+        .is_err());
+        drop(exclusive);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            crate::computer_use::acquire_virtual_display_shared(424_242),
+        )
+        .await
+        .unwrap();
     }
 }

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -1036,6 +1036,24 @@ pub fn select_provider_with_overrides(
 pub fn select_cu_provider(
     cu_config: &crate::project::ComputerUseConfig,
 ) -> Result<Box<dyn ChatProvider>, CallerError> {
+    select_cu_provider_with_tools(cu_config, vec![crate::tools::escalate_to_agent_tool()])
+}
+
+/// Select a native computer-use provider without exposing any function tool.
+///
+/// The bounded CU lane uses this selector so neither escalation nor a general
+/// agent capability exists in the provider request. Native computer actions
+/// remain available and are separately constrained by the bounded runner.
+pub fn select_bounded_cu_provider(
+    cu_config: &crate::project::ComputerUseConfig,
+) -> Result<Box<dyn ChatProvider>, CallerError> {
+    select_cu_provider_with_tools(cu_config, Vec::new())
+}
+
+fn select_cu_provider_with_tools(
+    cu_config: &crate::project::ComputerUseConfig,
+    cu_tools: Vec<ToolDefinition>,
+) -> Result<Box<dyn ChatProvider>, CallerError> {
     let provider_str = cu_config
         .provider
         .as_deref()
@@ -1055,9 +1073,6 @@ pub fn select_cu_provider(
     );
     let gemini_key = provider_auth_for("GEMINI_API_KEY", crate::credential_egress::KIND_GEMINI);
 
-    // CU providers get native CU tools + escalation function tool
-    let escalate_tools = vec![crate::tools::escalate_to_agent_tool()];
-
     match provider_str.as_deref() {
         Some("gemini") => {
             let key = gemini_key.ok_or_else(|| {
@@ -1067,7 +1082,7 @@ pub fn select_cu_provider(
             let display = crate::vision::display_resolution_for_provider("gemini");
             let ctx = resolve_context_window(&model);
             let max_out = resolve_max_output_tokens(&model);
-            let mut p = GeminiProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
+            let mut p = GeminiProvider::new_with_tools(key, model, ctx, max_out, cu_tools);
             p.cu_enabled = true;
             p.cu_display = Some(display);
             Ok(Box::new(p))
@@ -1080,7 +1095,7 @@ pub fn select_cu_provider(
             let display = crate::vision::display_resolution_for_provider("anthropic");
             let ctx = resolve_context_window(&model);
             let max_out = resolve_max_output_tokens(&model);
-            let mut p = AnthropicProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
+            let mut p = AnthropicProvider::new_with_tools(key, model, ctx, max_out, cu_tools);
             p.cu_enabled = true;
             p.cu_display = Some(display);
             Ok(Box::new(p))
@@ -1094,7 +1109,7 @@ pub fn select_cu_provider(
             let display = crate::vision::display_resolution_for_provider("openai");
             let ctx = resolve_context_window(&model);
             let max_out = resolve_max_output_tokens(&model);
-            let mut p = OpenAIProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
+            let mut p = OpenAIProvider::new_with_tools(key, model, ctx, max_out, cu_tools);
             p.set_cu_enabled(true);
             p.cu_display = Some(display);
             Ok(Box::new(p))
@@ -1119,7 +1134,7 @@ pub fn select_cu_provider(
                     model,
                     ctx,
                     max_out,
-                    escalate_tools,
+                    cu_tools,
                 );
                 p.set_cu_enabled(true);
                 p.cu_display = Some(display);
@@ -1129,8 +1144,7 @@ pub fn select_cu_provider(
                 let display = crate::vision::display_resolution_for_provider("anthropic");
                 let ctx = resolve_context_window(&model);
                 let max_out = resolve_max_output_tokens(&model);
-                let mut p =
-                    AnthropicProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
+                let mut p = AnthropicProvider::new_with_tools(key, model, ctx, max_out, cu_tools);
                 p.cu_enabled = true;
                 p.cu_display = Some(display);
                 Ok(Box::new(p))
@@ -1139,8 +1153,7 @@ pub fn select_cu_provider(
                 let display = crate::vision::display_resolution_for_provider("gemini");
                 let ctx = resolve_context_window(&model);
                 let max_out = resolve_max_output_tokens(&model);
-                let mut p =
-                    GeminiProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
+                let mut p = GeminiProvider::new_with_tools(key, model, ctx, max_out, cu_tools);
                 p.cu_enabled = true;
                 p.cu_display = Some(display);
                 Ok(Box::new(p))

--- a/src/bin/caller/startup/mcp_mode.rs
+++ b/src/bin/caller/startup/mcp_mode.rs
@@ -160,6 +160,7 @@ pub(crate) async fn run_mcp_mode(
         .map(|gateway| gateway.peer_registry.clone());
     mcp_app_state.peer_registry = mcp_peer_registry.clone();
     mcp_app_state.screenshot_dir = Some(log_dir.join("screenshots"));
+    mcp_app_state.computer_use_config = project.config.computer_use.clone();
     // The stdio MCP client is itself an answerable frontend (it receives
     // UserQuestion events and can send answer_question), and a dashboard
     // can attach through the optional gateway — asks block, never

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -326,6 +326,7 @@ pub(crate) fn spawn_mode_web_gateway(
     mcp_http_state.peer_registry = Some(peer_registry.clone());
     mcp_http_state.event_ring = event_ring;
     mcp_http_state.screenshot_dir = Some(log_dir.join("screenshots"));
+    mcp_http_state.computer_use_config = project.config.computer_use.clone();
     // The gateway shape always has an answerable frontend: a dashboard can
     // attach while an `ask_user` blocks, so asks wait instead of
     // auto-answering.

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -417,6 +417,17 @@ pub(crate) async fn destroy_virtual_display(
         return;
     }
 
+    // Refuse a stale exact-generation request before waiting on a replacement
+    // proof fence. Validate again after the wait so a future caller that does
+    // not hold the serial ownership loop cannot turn this fast check into a
+    // check-then-teardown race.
+    if let Some(reason) =
+        virtual_display_destroy_target_error(guards, display_id, capture_generation)
+    {
+        refuse_virtual_display_destroy(bus, request_id, reason);
+        return;
+    }
+
     // A bounded proof task owns the exclusive side of this gate from its
     // first resource check through its final receipt. Teardown therefore
     // cannot invalidate the generation between a check and injected input.
@@ -428,31 +439,10 @@ pub(crate) async fn destroy_virtual_display(
         eprintln!("[virtual_display] skipped cancelled destroy request {request_id}");
         return;
     }
-
-    let Some(ownership) = guards.get(&display_id) else {
-        refuse_virtual_display_destroy(
-            bus,
-            request_id,
-            format!("display :{display_id} is not a daemon-owned virtual display"),
-        );
-        return;
-    };
-    if ownership.capture_generation != capture_generation {
-        refuse_virtual_display_destroy(
-            bus,
-            request_id,
-            format!(
-                "capture generation does not match the live daemon-owned display :{display_id}"
-            ),
-        );
-        return;
-    }
-    if !guards.owns_generation(display_id, capture_generation) {
-        refuse_virtual_display_destroy(
-            bus,
-            request_id,
-            format!("display :{display_id} has incomplete daemon ownership state"),
-        );
+    if let Some(reason) =
+        virtual_display_destroy_target_error(guards, display_id, capture_generation)
+    {
+        refuse_virtual_display_destroy(bus, request_id, reason);
         return;
     }
     let Some(guard) = guards.remove(&display_id) else {
@@ -526,6 +516,29 @@ pub(crate) async fn destroy_virtual_display(
     );
 }
 
+fn virtual_display_destroy_target_error(
+    guards: &VirtualDisplayGuards,
+    display_id: u32,
+    capture_generation: &str,
+) -> Option<String> {
+    let Some(ownership) = guards.get(&display_id) else {
+        return Some(format!(
+            "display :{display_id} is not a daemon-owned virtual display"
+        ));
+    };
+    if ownership.capture_generation != capture_generation {
+        return Some(format!(
+            "capture generation does not match the live daemon-owned display :{display_id}"
+        ));
+    }
+    if !guards.owns_generation(display_id, capture_generation) {
+        return Some(format!(
+            "display :{display_id} has incomplete daemon ownership state"
+        ));
+    }
+    None
+}
+
 fn refuse_virtual_display_destroy(bus: &EventBus, request_id: &str, reason: String) {
     let _ = bus.complete_virtual_display_destroy(
         request_id,
@@ -560,6 +573,21 @@ async fn retire_virtual_display_generation(
     capture_generation: &str,
     reason: &str,
 ) {
+    // Reject a delayed loss event before waiting on a potentially long-lived
+    // proof fence held by a replacement generation that reused this numeric
+    // display id. Recheck after acquiring the gate to close the race with a
+    // same-generation teardown or replacement during the await.
+    match guards.get(&display_id) {
+        None => return,
+        Some(ownership) if ownership.capture_generation != capture_generation => {
+            eprintln!(
+                "[virtual_display] ignored stale capture generation {capture_generation} for :{display_id}"
+            );
+            return;
+        }
+        Some(_) => {}
+    }
+
     // Capture loss is a lifecycle mutation too. Acquire before removing the
     // session so a bounded proof cannot pass its final binding check against
     // a session whose teardown has already begun.
@@ -839,6 +867,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_capture_loss_does_not_wait_for_reused_display_proof_fence() {
+        let display_id = 400_000 + (uuid::Uuid::new_v4().as_u128() as u32 % 100_000);
+        let bus = EventBus::new();
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::display::SessionRegistry::new(),
+        ));
+        let mut guards = VirtualDisplayGuards::new();
+        guards.ownership.insert(
+            display_id,
+            VirtualDisplayOwnership {
+                capture_generation: "generation-replacement".to_string(),
+                request_id: None,
+                width: 1280,
+                height: 720,
+            },
+        );
+        let replacement_proof =
+            crate::computer_use::acquire_virtual_display_exclusive(display_id).await;
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            handle_virtual_display_capture_lost(
+                &bus,
+                &registry,
+                &mut guards,
+                display_id,
+                "generation-retired",
+                "delayed stale capture loss",
+            ),
+        )
+        .await
+        .expect("a stale loss event must not wait on the replacement proof fence");
+
+        assert_eq!(
+            guards
+                .get(&display_id)
+                .map(|ownership| ownership.capture_generation.as_str()),
+            Some("generation-replacement")
+        );
+        drop(replacement_proof);
+    }
+
+    #[tokio::test]
     async fn readiness_and_loss_are_scoped_to_one_capture_generation() {
         let bus = EventBus::new();
         let mut events = bus.subscribe();
@@ -1002,7 +1073,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stale_destroy_generation_is_refused_without_touching_live_ownership() {
+    async fn stale_destroy_generation_is_refused_without_waiting_for_replacement_proof() {
+        let display_id = 500_000 + (uuid::Uuid::new_v4().as_u128() as u32 % 100_000);
         let bus = EventBus::new();
         let waiter = bus
             .register_virtual_display_destroy_waiter("vdd-stale".to_string())
@@ -1012,7 +1084,7 @@ mod tests {
         ));
         let mut guards = VirtualDisplayGuards::new();
         guards.ownership.insert(
-            199,
+            display_id,
             VirtualDisplayOwnership {
                 capture_generation: "generation-live".to_string(),
                 request_id: None,
@@ -1020,31 +1092,39 @@ mod tests {
                 height: 720,
             },
         );
+        let replacement_proof =
+            crate::computer_use::acquire_virtual_display_exclusive(display_id).await;
 
-        destroy_virtual_display(
-            &bus,
-            &registry,
-            &mut guards,
-            "vdd-stale",
-            199,
-            "generation-old",
-            None,
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            destroy_virtual_display(
+                &bus,
+                &registry,
+                &mut guards,
+                "vdd-stale",
+                display_id,
+                "generation-old",
+                None,
+            ),
         )
-        .await;
+        .await
+        .expect("a stale destroy must not wait on the replacement proof fence");
 
         assert_eq!(
             waiter.wait(Duration::from_millis(100)).await,
             Ok(VirtualDisplayDestroyOutcome::Refused {
-                reason: "capture generation does not match the live daemon-owned display :199"
-                    .to_string(),
+                reason: format!(
+                    "capture generation does not match the live daemon-owned display :{display_id}"
+                ),
             })
         );
         assert_eq!(
             guards
-                .get(&199)
+                .get(&display_id)
                 .map(|ownership| ownership.capture_generation.as_str()),
             Some("generation-live")
         );
+        drop(replacement_proof);
     }
 
     #[tokio::test]

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -25,7 +25,7 @@ use crate::frames;
 use crate::types::LogLevel;
 use crate::vision;
 use intendant_platform::DisplayTarget;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -47,9 +47,9 @@ pub(crate) struct VirtualDisplayGuards {
     ownership: HashMap<u32, VirtualDisplayOwnership>,
 }
 
-fn browser_bindable_displays() -> &'static Mutex<HashSet<u32>> {
-    static DISPLAYS: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
-    DISPLAYS.get_or_init(|| Mutex::new(HashSet::new()))
+fn browser_bindable_displays() -> &'static Mutex<HashMap<u32, String>> {
+    static DISPLAYS: OnceLock<Mutex<HashMap<u32, String>>> = OnceLock::new();
+    DISPLAYS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Whether this exact daemon-owned display participates in the correlated
@@ -58,7 +58,7 @@ fn browser_bindable_displays() -> &'static Mutex<HashSet<u32>> {
 pub(crate) fn process_owns_browser_bindable_display(display_id: u32) -> bool {
     let lifecycle_owned = browser_bindable_displays()
         .lock()
-        .is_ok_and(|displays| displays.contains(&display_id))
+        .is_ok_and(|displays| displays.contains_key(&display_id))
         && vision::process_owns_virtual_display(display_id);
     #[cfg(target_os = "linux")]
     {
@@ -71,9 +71,20 @@ pub(crate) fn process_owns_browser_bindable_display(display_id: u32) -> bool {
     }
 }
 
-fn register_browser_bindable_display(display_id: u32) {
+/// Whether the exact opaque generation returned by `create_virtual_display`
+/// still owns this daemon-created, capture-ready display.
+pub(crate) fn process_owns_browser_bindable_display_generation(
+    display_id: u32,
+    capture_generation: &str,
+) -> bool {
+    browser_bindable_displays().lock().is_ok_and(|displays| {
+        displays.get(&display_id).map(String::as_str) == Some(capture_generation)
+    }) && process_owns_browser_bindable_display(display_id)
+}
+
+fn register_browser_bindable_display(display_id: u32, capture_generation: &str) {
     if let Ok(mut displays) = browser_bindable_displays().lock() {
-        displays.insert(display_id);
+        displays.insert(display_id, capture_generation.to_string());
     }
 }
 
@@ -352,7 +363,7 @@ pub(crate) async fn handle_virtual_display_capture_readiness(
     // A browser may bind only after capture has stayed live through the
     // readiness window. Before this point the X server exists but is not a
     // usable, evidence-producing workspace.
-    register_browser_bindable_display(display_id);
+    register_browser_bindable_display(display_id, capture_generation);
 
     let request_id = ownership.request_id.clone();
     let width = ownership.width;

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -417,6 +417,18 @@ pub(crate) async fn destroy_virtual_display(
         return;
     }
 
+    // A bounded proof task owns the exclusive side of this gate from its
+    // first resource check through its final receipt. Teardown therefore
+    // cannot invalidate the generation between a check and injected input.
+    let _display_access = crate::computer_use::acquire_virtual_display_shared(display_id).await;
+    // The proof task may hold the exclusive side for minutes. A caller that
+    // disconnected while this destroy waited must not leave a delayed
+    // destructive intent behind.
+    if !bus.virtual_display_destroy_is_pending(request_id) {
+        eprintln!("[virtual_display] skipped cancelled destroy request {request_id}");
+        return;
+    }
+
     let Some(ownership) = guards.get(&display_id) else {
         refuse_virtual_display_destroy(
             bus,
@@ -650,6 +662,7 @@ pub(crate) async fn reap_virtual_display(
     display_id: u32,
     context: &str,
 ) -> bool {
+    let _display_access = crate::computer_use::acquire_virtual_display_shared(display_id).await;
     let guard = guards.remove(&display_id);
     // The browser registry lock serializes both sides of this transition:
     // creation checks bindability and reserves Starting under the same lock,

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -560,6 +560,10 @@ async fn retire_virtual_display_generation(
     capture_generation: &str,
     reason: &str,
 ) {
+    // Capture loss is a lifecycle mutation too. Acquire before removing the
+    // session so a bounded proof cannot pass its final binding check against
+    // a session whose teardown has already begun.
+    let _display_access = crate::computer_use::acquire_virtual_display_shared(display_id).await;
     let Some(ownership) = guards.get(&display_id) else {
         return;
     };
@@ -581,7 +585,7 @@ async fn retire_virtual_display_generation(
     if let Some(session) = session_registry.write().await.remove(display_id) {
         session.stop().await;
     }
-    reap_virtual_display(bus, guards, display_id, "capture unavailable").await;
+    reap_virtual_display_with_access(bus, guards, display_id, "capture unavailable").await;
     if let Some(request_id) = request_id {
         let _ = bus.complete_virtual_display_create(
             &request_id,
@@ -663,6 +667,15 @@ pub(crate) async fn reap_virtual_display(
     context: &str,
 ) -> bool {
     let _display_access = crate::computer_use::acquire_virtual_display_shared(display_id).await;
+    reap_virtual_display_with_access(bus, guards, display_id, context).await
+}
+
+async fn reap_virtual_display_with_access(
+    bus: &EventBus,
+    guards: &mut VirtualDisplayGuards,
+    display_id: u32,
+    context: &str,
+) -> bool {
     let guard = guards.remove(&display_id);
     // The browser registry lock serializes both sides of this transition:
     // creation checks bindability and reserves Starting under the same lock,


### PR DESCRIPTION
Adds an owner-only `intendant ctl cu task` lane for evidence capture on an exact daemon-owned display generation and attempt-leased local CDP workspace.

The stage path exposes only bounded native computer actions; attestation gets one internally captured frame and rejects every later action. No function tools, shell, filesystem, browser API, delegation, or escalation are sent to the provider. Resource bindings are checked around every action, concurrent tasks on one display generation are refused, scratch space is private and removed before return, and the compact receipt binds all fields plus frame/action/task/result lineage.

Also wires the project CU provider config through daemon MCP state, makes virtual-display generations queryable exactly, adds the CLI/facade surface, and documents the contract.

Verification:
- `cargo clippy --bin intendant --no-default-features -- -D warnings`
- `cargo test --bin intendant --locked` (6,089 passed; 10 ignored)
- 11 focused bounded-CU hostile-path tests
- `cargo fmt --all -- --check`