### PR TITLE
Allocate external proof displays from the reserved capture pool

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -666,6 +666,24 @@ jobs:
           retention-days: 14
           overwrite: true
 
+      - name: Provider-free external CU proof acceptance
+        if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          bin="${CARGO_TARGET_DIR:-$GITHUB_WORKSPACE/target}/${{ matrix.target }}/debug/intendant"
+          evidence="${{ steps.daemon.outputs.rig }}/artifacts/external-cu-proof"
+          python3 scripts/test-external-cu-proof.py --bin "$bin" --evidence "$evidence"
+
+      - name: Upload external CU proof evidence
+        if: always() && runner.os == 'Linux' && steps.daemon.outputs.rig != '' && steps.relevance_unix.outputs.relevant != 'false'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: external-cu-proof-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.daemon.outputs.rig }}/artifacts/external-cu-proof/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Stop daemon (dashboard-boot)
         if: always() && steps.daemon.outputs.pid != ''
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -673,6 +673,7 @@ jobs:
         run: |
           bin="${CARGO_TARGET_DIR:-$GITHUB_WORKSPACE/target}/${{ matrix.target }}/debug/intendant"
           evidence="${{ steps.daemon.outputs.rig }}/artifacts/external-cu-proof"
+          python3 scripts/test-external-cu-proof-discovery.py
           python3 scripts/test-external-cu-proof.py --bin "$bin" --evidence "$evidence"
 
       - name: Upload external CU proof evidence

--- a/crates/intendant-display/src/x11_input.rs
+++ b/crates/intendant-display/src/x11_input.rs
@@ -356,15 +356,17 @@ where
 // ── Low-level XTest primitives (blocking) ────────────────────────────────────
 
 fn fake_motion(dc: &DisplayConn, x: i32, y: i32) -> Result<(), OpError> {
-    dc.conn.xtest_fake_input(
-        xproto::MOTION_NOTIFY_EVENT,
-        0, // absolute
-        x11rb::CURRENT_TIME,
-        dc.root,
-        x.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
-        y.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
-        0,
-    )?;
+    dc.conn
+        .xtest_fake_input(
+            xproto::MOTION_NOTIFY_EVENT,
+            0, // absolute
+            x11rb::CURRENT_TIME,
+            dc.root,
+            x.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+            y.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+            0,
+        )?
+        .check()?;
     Ok(())
 }
 
@@ -375,7 +377,8 @@ fn fake_button(dc: &DisplayConn, button: u8, press: bool) -> Result<(), OpError>
         xproto::BUTTON_RELEASE_EVENT
     };
     dc.conn
-        .xtest_fake_input(kind, button, x11rb::CURRENT_TIME, x11rb::NONE, 0, 0, 0)?;
+        .xtest_fake_input(kind, button, x11rb::CURRENT_TIME, x11rb::NONE, 0, 0, 0)?
+        .check()?;
     Ok(())
 }
 
@@ -386,7 +389,8 @@ fn fake_key(dc: &DisplayConn, keycode: u8, press: bool) -> Result<(), OpError> {
         xproto::KEY_RELEASE_EVENT
     };
     dc.conn
-        .xtest_fake_input(kind, keycode, x11rb::CURRENT_TIME, x11rb::NONE, 0, 0, 0)?;
+        .xtest_fake_input(kind, keycode, x11rb::CURRENT_TIME, x11rb::NONE, 0, 0, 0)?
+        .check()?;
     Ok(())
 }
 

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -124,14 +124,12 @@ pub fn display_resolution_for_provider(provider_name: &str) -> (u32, u32) {
 // ── Display allocation ──────────────────────────────────────────────────────
 
 /// Preferred display number.
-#[cfg(target_os = "linux")]
-const PREFERRED_DISPLAY: u32 = 99;
+pub const PREFERRED_DISPLAY: u32 = 99;
 
 /// One past the last display number [`find_free_display`] will allocate.
 /// `:99..:199` is the agent virtual-display range; sockets outside it are
 /// treated as user/session X servers, never as reclaimable Xvfb instances.
-#[cfg(target_os = "linux")]
-const VIRTUAL_DISPLAY_END: u32 = 200;
+pub const VIRTUAL_DISPLAY_END: u32 = 200;
 
 #[cfg(target_os = "linux")]
 static OWNED_XVFB_PROCESSES: OnceLock<Mutex<HashMap<u32, OwnedXvfbProcess>>> = OnceLock::new();

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,6 +19,7 @@
 - [Trust Architecture](./trust-architecture.md)
 - [Trust Tiers](./trust-tiers.md)
 - [Computer Use & Live Audio](./computer-use-and-audio.md)
+- [Externally driven CU proof sessions](./external-cu-proof.md)
 - [Presence Layer](./presence.md)
 - [Autonomy & Approvals](./autonomy.md)
 - [Web Dashboard](./web-dashboard.md)

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -95,6 +95,53 @@ element): multi-line/control text (Return may submit, Tab may move focus),
 secure fields, and elements without an AX-readable value stay `injected`
 with the reason in the result detail.
 
+### Externally driven proof sessions (no internal model)
+
+Ordinary `ctl cu actions` never needs a model provider. For evidence work,
+`ctl cu proof --request JSON|@file|-` adds an owner-bound, multi-call recording
+session without delegating to another model. The current external agent sends
+explicit actions and receives private PNG observations. No provider selection
+or LLM request exists in this path; `cu task` below remains an optional
+model-backed orchestration convenience.
+
+The request is bounded, duplicate-key-safe JSON. `begin` pins the job digest,
+attempt, ready local CDP workspace, leased display and exact display generation.
+The daemon records the actor resolved by the authenticating control surface;
+request fields cannot substitute that identity. Continuations require the same
+actor, opaque proof ID and exact sequence. `status` reconciles a lost response;
+replayed or out-of-order mutations do not repeat input.
+
+The phase sequence is `begin -> actions -> freeze -> observe -> finish -> close`.
+The worker owns the display lock across all calls. Stage is limited to 180
+seconds, 64 total actions and 16 actions per batch. Clipboard paste, split
+mouse edges and cropped frames are forbidden. Freeze permanently disables
+further actions and starts a 45-second completion deadline. Observe binds one
+full-display PNG to the caller's pre-capture observation digest. Finish records
+the external caller's claims about exactly that image; it does not independently
+validate those claims or authorize a CDN submission. The lock remains held until
+close, so a caller can verify post-capture browser state before releasing it.
+
+Every native operation uses the same generation, lease, input-sealing, private
+scratch and cancellation-safe executor as the bounded task. Disconnecting an
+HTTP call does not discard the worker's fence while OS input is in flight;
+unattended sessions expire. Close is acknowledged only after executor cleanup.
+The owner-side caller still closes its browser, destroys its exact display
+generation and removes its private profile.
+
+The separate v2 external receipt identifies `external-actions`, reports zero
+internal model calls, and binds the authenticated actor, action/frame transcript,
+external claim bytes and frozen PNG. Typed text and key values (including their
+hashes) are excluded from the public action projection. Receipt hashes provide
+content integrity, not independent authentication or policy approval: consumers
+must retain their pinned authenticated transport and require the matching close
+acknowledgement. They must not relabel this receipt as a legacy model attestation.
+
+`python3 scripts/test-external-cu-proof.py --bin /absolute/intendant --evidence
+/private/new-directory` exercises real native input, PNG changes, replay and
+freeze refusal, exact closure, idle expiry, and foreign-Xvfb/CI isolation on Linux.
+It starts a separate credential-free loopback daemon and never uses the user's
+physical display.
+
 ### Bounded proof tasks
 
 `intendant ctl cu task` is the owner-only orchestration lane for evidence

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -142,6 +142,8 @@ freeze refusal, exact closure, idle expiry, and foreign-Xvfb/CI isolation on Lin
 It starts a separate credential-free loopback daemon and never uses the user's
 physical display.
 
+See [Externally driven CU proof sessions](./external-cu-proof.md) for the complete provider-free protocol.
+
 ### Bounded proof tasks
 
 `intendant ctl cu task` is the owner-only orchestration lane for evidence

--- a/docs/src/external-cu-proof.md
+++ b/docs/src/external-cu-proof.md
@@ -1,0 +1,99 @@
+# Externally driven CU proof sessions
+
+Computer-use execution does not require a model. `cu actions` executes explicit
+input; `cu proof` adds an attempt-bound evidence session around explicit input.
+Only the optional `cu task` command delegates natural-language instructions to
+an internal model. Its provider configuration is not a prerequisite for either
+explicit-action interface.
+
+## Authority and ownership
+
+`external_cu_proof` is an owner-surface tool. Its actor comes from the existing
+MCP gate, not from request JSON. A session binds one daemon-created virtual
+display generation, one local CDP workspace owned by the attempt, and that
+workspace's `scout_cdn_capture` lease. Another actor cannot inspect or continue
+the session. User-session displays, foreign displays, stale generations and
+second active workspaces on the proof display are refused.
+
+The worker retains the native display-exclusion guard across tool calls. It
+seals browser-interactive input, uses the existing native execution and
+cancellation-cleanup machinery, and does not construct a provider, conversation,
+function-tool surface or delegation. An abandoned session expires independently
+of the caller. There are at most eight generic sessions per daemon; the Scout
+controller additionally holds its existing single-capture host lease.
+
+## Wire protocol
+
+Use `intendant ctl cu proof --request JSON|@file|-`. The request is kept as raw
+JSON until duplicate-key validation in the daemon. Unknown fields are rejected.
+The MCP equivalent is `external_cu_proof` with one `request` string.
+
+Begin with the actual owned resource identities:
+
+```json
+{
+  "op": "begin",
+  "attempt_id": "cdn-attempt:example",
+  "workspace_id": "bw-actual-workspace",
+  "display_id": 120,
+  "display_target": "display_120",
+  "capture_generation": "vdcg-actual-generation",
+  "job_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+}
+```
+
+The example digest is illustrative, not candidate evidence. Scout supplies the
+validated job digest. The response includes `proofId`, `sequence: 0`, the
+authenticated `actor`, immutable `binding`, and a private full-display PNG frame.
+Every mutation must use the current sequence; accepted mutations advance it
+once. A batch contains 1–16 actions and the session permits at most 64 actions.
+Actions are prevalidated as a whole before any member is executed. Paste,
+split mouse-down/up edges, cropped zoom frames and arbitrary fields are refused.
+
+```json
+{"op":"actions","proof_id":"ecup-actual-id","sequence":0,"actions_json":"[{\"type\":\"click\",\"x\":100,\"y\":150}]"}
+```
+
+The phase order is:
+
+1. `begin` and `actions`: arrange and inspect the proof, within 180 seconds
+   including setup. `status` observes state without advancing the sequence.
+2. `freeze`: permanently reject further actions. No unfreeze operation exists.
+   This freezes input, not the website's JavaScript or animation.
+3. The controller independently records the browser's pre-capture CDP state.
+   `observe` receives its `pre_observation_sha256` and captures one fresh PNG.
+4. `finish` receives the exact issued `observation_sha256` and duplicate-key-safe
+   `claims_json`. Claims are attributed to the external caller. The caller must
+   inspect that image; it cannot substitute a later screenshot.
+5. The controller checks post-capture CDP state while the guard is still held.
+   `close` then releases the proof guard and acknowledges cleanup against the
+   exact receipt ID. The controller closes its browser/display/profile.
+
+The frozen phase has a fixed 45-second budget, including observation and claims.
+`abort` is always available with the current sequence. A lost action response is
+not permission to replay input: inspect `status`. If a terminal acknowledgement
+is lost, do not infer success from the earlier receipt. Expired or failed
+sessions require honest failure handling and, where appropriate, a new attempt.
+
+## Evidence semantics
+
+Version 2 uses profile `intendant-external-cu-proof-v1`, distinct from the
+model-backed version 1 receipt. It records actor/resource/job bindings, bounded
+timing and counters, a redacted action transcript, the input-freeze boundary,
+exact observation bytes/dimensions/digest, and external claims. It explicitly
+records `internalModelCalls: 0`, `claimsAuthority: external-caller`, and
+`grantsSubmissionAuthority: false`. It never fabricates provider/model identity
+or calls an external assertion an independent policy review.
+
+Transcript and receipt digests use a domain string followed by a NUL byte and
+key-sorted JSON. Domains are `intendant-external-cu-stage-v1`,
+`intendant-external-cu-transcript-v1`, and `intendant-external-cu-receipt-v1`.
+The receipt ID hashes the payload without `receiptId`. These are integrity
+bindings, not digital signatures: consumers must obtain the records from the
+authenticated control channel and bind them to their admitted job and actor.
+
+Frames, raw claims and host-resource diagnostics are private. The transcript
+redacts typed text and key values. It records this interface's execution, not a
+claim that the external agent performed no unrelated operations anywhere else.
+Sealing, timestamp verification, policy review and owner submission approval
+remain separate boundaries.

--- a/docs/src/external-cu-proof.md
+++ b/docs/src/external-cu-proof.md
@@ -97,3 +97,10 @@ redacts typed text and key values. It records this interface's execution, not a
 claim that the external agent performed no unrelated operations anywhere else.
 Sealing, timestamp verification, policy review and owner submission approval
 remain separate boundaries.
+
+For Scout, allocate directly from its reserved pool: `intendant ctl display
+create --min-display-id 120 --max-display-id 159`. Both bounds are required
+when either is supplied, must be an inclusive subset of Intendant’s managed
+99–199 pool, and exhaustion fails without spilling into another pool. Ordinary
+callers omitting both bounds retain the existing allocator. No filler displays
+are created and foreign sockets remain excluded.

--- a/scripts/test-external-cu-proof-discovery.py
+++ b/scripts/test-external-cu-proof-discovery.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Hermetic browser-discovery coverage; no display or real browser is opened."""
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+spec = importlib.util.spec_from_file_location('external_proof_test', Path(__file__).with_name('test-external-cu-proof.py'))
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+class BrowserDiscovery(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.binary = Path(self.temp.name) / 'browser'
+        self.binary.write_text('#!/bin/sh\nexit 0\n')
+        self.binary.chmod(0o700)
+    def tearDown(self):
+        self.temp.cleanup()
+    def test_explicit_override(self):
+        self.assertEqual(module.resolve_browser(self.binary, {}, lambda _: None), str(self.binary.resolve()))
+    def test_environment_override(self):
+        self.assertEqual(module.resolve_browser(None, {'INTENDANT_BROWSER_WORKSPACE_EXECUTABLE': str(self.binary)}, lambda _: None), str(self.binary.resolve()))
+    def test_chrome_on_path_without_distro_path(self):
+        calls = []
+        def which(name):
+            calls.append(name)
+            return str(self.binary) if name == 'google-chrome' else None
+        self.assertEqual(module.resolve_browser(None, {}, which), str(self.binary.resolve()))
+        self.assertEqual(calls, ['google-chrome-stable', 'google-chrome'])
+    def test_invalid_override_does_not_fallback(self):
+        for path in ['relative', str(self.binary.parent), str(self.binary.parent / 'absent')]:
+            with self.assertRaises(RuntimeError):
+                module.resolve_browser(path, {}, lambda _: str(self.binary))
+    def test_missing_or_non_executable_browser_refused(self):
+        with self.assertRaises(RuntimeError):
+            module.resolve_browser(None, {}, lambda _: None)
+        self.binary.chmod(0o600)
+        with self.assertRaises(RuntimeError):
+            module.resolve_browser(self.binary, {}, lambda _: str(self.binary))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test-external-cu-proof.py
+++ b/scripts/test-external-cu-proof.py
@@ -124,7 +124,7 @@ def main():
     def create_owned_browser():
         nonlocal workspace, display
         display = call('display', 'create', '--width', '1280', '--height', '900',
-                       '--minimum-display-id', '120', '--maximum-display-id', '159')
+                       '--min-display-id', '120', '--max-display-id', '159')
         require(display.get('ok') is True, 'display create')
         require(120 <= display['display_id'] <= 159, 'display escaped reserved capture pool')
         attempt = 'cdn-external-test-' + uuid.uuid4().hex

--- a/scripts/test-external-cu-proof.py
+++ b/scripts/test-external-cu-proof.py
@@ -123,8 +123,10 @@ def main():
 
     def create_owned_browser():
         nonlocal workspace, display
-        display = call('display', 'create', '--width', '1280', '--height', '900')
+        display = call('display', 'create', '--width', '1280', '--height', '900',
+                       '--minimum-display-id', '120', '--maximum-display-id', '159')
         require(display.get('ok') is True, 'display create')
+        require(120 <= display['display_id'] <= 159, 'display escaped reserved capture pool')
         attempt = 'cdn-external-test-' + uuid.uuid4().hex
         workspace = call('browser', 'create', f'http://127.0.0.1:{server.server_port}/', '--provider', 'cdp',
                          '--display-target', display['display_target'], '--profile-dir', str(root / ('profile-' + attempt)),

--- a/scripts/test-external-cu-proof.py
+++ b/scripts/test-external-cu-proof.py
@@ -54,11 +54,29 @@ class Page(http.server.BaseHTTPRequestHandler):
         pass
 
 
+def resolve_browser(explicit=None, environ=None, which=None):
+    """Resolve a test browser without assuming a distribution's package layout."""
+    environ = os.environ if environ is None else environ
+    which = shutil.which if which is None else which
+    override = explicit or environ.get('INTENDANT_BROWSER_WORKSPACE_EXECUTABLE')
+    if override:
+        path = Path(override).expanduser()
+        require(path.is_absolute() and path.is_file() and os.access(path, os.X_OK),
+                'explicit browser must be an absolute executable file')
+        return str(path.resolve())
+    for name in ('google-chrome-stable', 'google-chrome', 'chromium', 'chromium-browser'):
+        located = which(name)
+        if located and Path(located).is_file() and os.access(located, os.X_OK):
+            return str(Path(located).resolve())
+    raise RuntimeError('Chrome/Chromium unavailable; supply --browser-bin ABSOLUTE_PATH')
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--bin', required=True, type=Path)
     parser.add_argument('--evidence', required=True, type=Path)
     parser.add_argument('--skip-expiry', action='store_true')
+    parser.add_argument('--browser-bin', type=Path)
     args = parser.parse_args()
     binary, out = args.bin.resolve(), args.evidence.resolve()
     require(sys.platform.startswith('linux'), 'Linux required')
@@ -74,7 +92,7 @@ def main():
     home.mkdir(mode=0o700)
     env = {'HOME': str(home), 'INTENDANT_HOME': str(home / '.intendant'),
            'PATH': os.environ.get('PATH', '/usr/bin:/bin'), 'LANG': 'C.UTF-8',
-           'INTENDANT_BROWSER_WORKSPACE_EXECUTABLE': '/usr/lib/chromium/chromium',
+           'INTENDANT_BROWSER_WORKSPACE_EXECUTABLE': resolve_browser(args.browser_bin),
            'INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER': '1'}
     require(Path(env['INTENDANT_BROWSER_WORKSPACE_EXECUTABLE']).is_file(), 'native Chromium missing')
     daemon = foreign = server = workspace = display = proof = None

--- a/scripts/test-external-cu-proof.py
+++ b/scripts/test-external-cu-proof.py
@@ -66,7 +66,9 @@ def main():
     os.umask(0o077)
     out.mkdir(mode=0o700, parents=True)
     runners = cutover.runner_snapshot()
-    require(not any(r['comm'] == 'Runner.Worker' for r in runners), 'CI has priority')
+    # Standalone rehearsal yields to CI; a CI job may run its own isolated test.
+    if os.environ.get('GITHUB_ACTIONS') != 'true':
+        require(not any(r['comm'] == 'Runner.Worker' for r in runners), 'CI has priority')
     root = Path(tempfile.mkdtemp(prefix='intendant-external-cu-'))
     home = root / 'home'
     home.mkdir(mode=0o700)

--- a/scripts/test-external-cu-proof.py
+++ b/scripts/test-external-cu-proof.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Real provider-free CU acceptance. Owns only temporary test resources."""
+import argparse
+import base64
+import hashlib
+import http.server
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+
+spec = importlib.util.spec_from_file_location('cutover', Path(__file__).with_name('test-linux-display-cutover.py'))
+cutover = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = cutover
+spec.loader.exec_module(cutover)
+
+
+def require(value, message):
+    if not value:
+        raise RuntimeError(message)
+
+
+def save(path, value):
+    path.write_text(json.dumps(value, sort_keys=True, indent=2) + '\n')
+    path.chmod(0o600)
+
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(('127.0.0.1', 0))
+        return sock.getsockname()[1]
+
+
+class Page(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = b'''<!doctype html><meta charset="utf-8"><title>EXTERNAL CU KEYLESS TEST</title>
+<style>html,body{margin:0;width:100%;height:100%;background:rgb(220,35,45)}input{position:absolute;inset:0;box-sizing:border-box;width:100%;height:100%;font:30px sans-serif;background:transparent;border:0}</style>
+<input autofocus id="proof" aria-label="Proof input" oninput="document.documentElement.style.background=document.body.style.background=this.value==='proof-ready'?'rgb(30,170,70)':'rgb(220,35,45)'">'''
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--bin', required=True, type=Path)
+    parser.add_argument('--evidence', required=True, type=Path)
+    parser.add_argument('--skip-expiry', action='store_true')
+    args = parser.parse_args()
+    binary, out = args.bin.resolve(), args.evidence.resolve()
+    require(sys.platform.startswith('linux'), 'Linux required')
+    require(not out.exists(), 'evidence path must be new')
+    os.umask(0o077)
+    out.mkdir(mode=0o700, parents=True)
+    runners = cutover.runner_snapshot()
+    require(not any(r['comm'] == 'Runner.Worker' for r in runners), 'CI has priority')
+    root = Path(tempfile.mkdtemp(prefix='intendant-external-cu-'))
+    home = root / 'home'
+    home.mkdir(mode=0o700)
+    env = {'HOME': str(home), 'INTENDANT_HOME': str(home / '.intendant'),
+           'PATH': os.environ.get('PATH', '/usr/bin:/bin'), 'LANG': 'C.UTF-8',
+           'INTENDANT_BROWSER_WORKSPACE_EXECUTABLE': '/usr/lib/chromium/chromium',
+           'INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER': '1'}
+    require(Path(env['INTENDANT_BROWSER_WORKSPACE_EXECUTABLE']).is_file(), 'native Chromium missing')
+    daemon = foreign = server = workspace = display = proof = None
+    daemon_log, foreign_log = (out / 'daemon.log').open('wb'), (out / 'foreign.log').open('wb')
+    port, checks, commands = free_port(), [], []
+
+    def call(*argv):
+        done = subprocess.run([str(binary), 'ctl', '--port', str(port), '--json', *argv],
+                              env=env, cwd=root, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, text=True, timeout=95)
+        commands.append({'command': list(argv[:3]), 'exit': done.returncode,
+                         'stdoutSha256': hashlib.sha256(done.stdout.encode()).hexdigest(),
+                         'stderrBytes': len(done.stderr)})
+        require(done.returncode == 0, f'ctl failed: {done.stderr[:200]} {done.stdout[:300]}')
+        return json.loads(done.stdout)
+
+    def request(body, okay=True):
+        result = call('cu', 'proof', '--request', json.dumps(body, separators=(',', ':')))
+        require(result.get('ok') is okay, f'proof result: {str(result)[:300]}')
+        return result
+
+    def mutate(op, **kwargs):
+        nonlocal proof
+        result = request({'op': op, 'proof_id': proof['proofId'], 'sequence': proof['sequence'], **kwargs})
+        if not result.get('closed'):
+            proof = result
+        return result
+
+    def create_owned_browser():
+        nonlocal workspace, display
+        display = call('display', 'create', '--width', '1280', '--height', '900')
+        require(display.get('ok') is True, 'display create')
+        attempt = 'cdn-external-test-' + uuid.uuid4().hex
+        workspace = call('browser', 'create', f'http://127.0.0.1:{server.server_port}/', '--provider', 'cdp',
+                         '--display-target', display['display_target'], '--profile-dir', str(root / ('profile-' + attempt)),
+                         '--session', attempt)
+        require(workspace.get('status') == 'ready', f'browser create: {workspace}')
+        workspace = call('browser', 'acquire', workspace['id'], '--holder', attempt,
+                         '--holder-kind', 'scout_cdn_capture', '--note', 'external proof acceptance')
+        return {'op': 'begin', 'attempt_id': attempt, 'workspace_id': workspace['id'],
+                'display_id': display['display_id'], 'display_target': display['display_target'],
+                'capture_generation': display['capture_generation'],
+                'job_sha256': hashlib.sha256(b'acceptance fixture, not candidate qualification').hexdigest()}
+
+    def destroy_owned():
+        nonlocal workspace, display
+        if workspace:
+            result = call('browser', 'close', workspace['id'], '--reason', 'external-proof-test-cleanup')
+            require(result.get('status') == 'closed', 'browser close')
+            pid = workspace['process_id']
+            cutover.wait_for(lambda: not Path(f'/proc/{pid}').exists(), 'browser process remains', 10)
+            profile = Path(workspace['profile_dir'])
+            require(profile.is_relative_to(root), 'profile ownership')
+            if profile.exists():
+                shutil.rmtree(profile)
+            workspace = None
+        if display:
+            result = call('display', 'destroy', str(display['display_id']), display['capture_generation'],
+                          '--note', 'external-proof-test-cleanup')
+            require(result.get('ok') is True, 'display destroy')
+            display = None
+
+    def listening():
+        with socket.socket() as sock:
+            return sock.connect_ex(('127.0.0.1', port)) == 0
+
+    try:
+        n = cutover.choose_foreign_display()
+        foreign = subprocess.Popen(['Xvfb', f':{n}', '-screen', '0', '640x480x24', '-nolisten', 'tcp'],
+                                   stdout=foreign_log, stderr=subprocess.STDOUT)
+        cutover.wait_for(lambda: Path(f'/tmp/.X11-unix/X{n}').exists(), 'foreign Xvfb did not start')
+        foreign_id = cutover.pid_signature(foreign.pid)
+        # Same loopback-only, per-boot-token test transport used by repository CI.
+        # This never changes the persistent service or its transport configuration.
+        daemon = subprocess.Popen([str(binary), '--web', str(port), '--bind', '127.0.0.1', '--no-tls', '--no-presence'],
+                                  env=env, cwd=root, stdin=subprocess.DEVNULL, stdout=daemon_log, stderr=subprocess.STDOUT)
+        cutover.wait_for(listening, 'daemon not listening', 30)
+        cutover.wait_for(lambda: call('status').get('phase') == 'idle', 'daemon not ready for authenticated control', 30)
+        checks.append('isolated daemon with no provider credentials')
+        display_baseline=call('display','list')
+        server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), Page)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        begin = create_owned_browser()
+        rejected = request(dict(begin, capture_generation='vdcg-stale'), False)
+        require(rejected['error']['code'] == 'bounded-cu-display-generation-mismatch', 'stale generation accepted')
+        checks.append('stale display generation refused')
+        proof = request(begin)
+        # CDP readiness and a fresh frame do not imply the first page paint.
+        # Wait for this fixture's pixels before sending any native input.
+        for paint_attempt in range(16):
+            paint_path=out/f'initial-paint-{paint_attempt}.png'
+            paint_path.write_bytes(base64.b64decode(proof['frame']['pngBase64'],validate=True))
+            pw,ph,pc,pr=cutover.decode_png(paint_path)
+            painted=(pw,ph)==(1280,900) and all(tuple(pr[y][x*pc:x*pc+3])==(220,35,45) for x,y in [(600,500),(900,700),(400,400)])
+            if painted:break
+            require(paint_attempt<15,'fixture did not become paint-ready before input')
+            mutate('actions',actions_json=json.dumps([{'type':'wait','ms':300}]))
+        checks.append(f'fixture paint ready before input after {paint_attempt} waits')
+        expected = {'binding': proof['binding'], 'actor': proof['actor'],
+                    'preObservationSha256': hashlib.sha256(b'acceptance pre-observation fixture').hexdigest()}
+        save(out / 'expected.json', expected)
+        require(request(begin, False)['error']['code'] == 'external-proof-busy', 'duplicate attempt accepted')
+        checks.append('exclusive attempt and display')
+        seq = proof['sequence']
+        bad_batch = [{'type': 'type', 'text': 'must-not-be-injected'}, {'type': 'paste', 'text': 'forbidden'}]
+        rejected = request({'op': 'actions', 'proof_id': proof['proofId'], 'sequence': seq,
+                            'actions_json': json.dumps(bad_batch)}, False)
+        require(rejected['error']['code'] == 'external-proof-action-forbidden', 'invalid batch accepted')
+        require(request({'op': 'status', 'proof_id': proof['proofId']})['sequence'] == seq, 'failed batch advanced')
+        checks.append('invalid batch refused before any input')
+        mutate('actions', actions_json=json.dumps([{'type': 'click', 'x': 180, 'y': 145}, {'type': 'wait', 'ms': 200},
+                                                   {'type': 'type', 'text': 'proof-ready'}, {'type': 'wait', 'ms': 300}]))
+        rejected = request({'op': 'actions', 'proof_id': proof['proofId'], 'sequence': 0,
+                            'actions_json': '[{"type":"type","text":"must-not-run"}]'}, False)
+        require(rejected['error']['code'] == 'external-proof-sequence', 'stale input replayed')
+        checks.append('stale action sequence refused')
+        mutate('freeze')
+        rejected = request({'op': 'actions', 'proof_id': proof['proofId'], 'sequence': proof['sequence'],
+                            'actions_json': '[{"type":"type","text":"must-not-run"}]'}, False)
+        require(rejected['error']['code'] == 'external-proof-phase', 'input after freeze accepted')
+        checks.append('irreversible input freeze')
+        mutate('observe', pre_observation_sha256=expected['preObservationSha256'])
+        (out / 'proof.png').write_bytes(base64.b64decode(proof['frame']['pngBase64'], validate=True))
+        width, height, channels, rows = cutover.decode_png(out / 'proof.png')
+        require((width, height) == (1280, 900), 'wrong PNG geometry')
+        samples = [tuple(rows[y][x * channels:x * channels + 3]) for x, y in [(600, 500), (900, 700), (400, 400)]]
+        input_effect_verified=all(rgb == (30,170,70) for rgb in samples)
+        if input_effect_verified:checks.append('real native typing changed visible page pixels')
+        rejected = request({'op': 'finish', 'proof_id': proof['proofId'], 'sequence': proof['sequence'],
+                            'observation_sha256': '0' * 64, 'claims_json': '{}'}, False)
+        require(rejected['error']['code'] == 'external-proof-observation', 'substituted frame accepted')
+        checks.append('claims bind exact issued frame')
+        mutate('finish', observation_sha256=proof['frame']['sha256'],
+               claims_json=json.dumps({'acceptanceFixture': True, 'observedGreenAfterNativeTyping': input_effect_verified}, separators=(',', ':')))
+        save(out / 'receipt.json', proof['receipt'])
+        closed = mutate('close')
+        save(out / 'close.json', closed)
+        require(closed.get('cleanupComplete') is True, 'proof close failed')
+        checks.append('receipt-bound native cleanup acknowledged')
+        proof = None
+        destroy_owned()
+        if not args.skip_expiry:
+            begin = create_owned_browser()
+            proof = request(begin)
+            mutate('freeze')
+            proof_id = proof['proofId']
+            time.sleep(46)
+            rejected = request({'op': 'status', 'proof_id': proof_id}, False)
+            require(rejected['error']['code'] == 'external-proof-not-found', 'abandoned proof did not expire')
+            checks.append('abandoned frozen session expires and releases fence')
+            proof = None
+            destroy_owned()
+        require(cutover.signature_live(foreign_id), 'foreign Xvfb changed')
+        require(cutover.runner_snapshot() == runners, 'CI runner identities changed')
+        checks.extend(['foreign Xvfb preserved', 'CI runner identities preserved'])
+        require(call('display','list') == display_baseline, 'managed display inventory changed after cleanup')
+        result = {'passed': input_effect_verified, 'inputEffectVerified': input_effect_verified, 'test': 'external-cu-proof-real-linux-v1', 'binarySha256': cutover.sha256_file(binary),
+                  'checks': checks, 'runners': runners, 'foreign': foreign_id, 'pngSamples': samples, 'commands': commands}
+        save(out / 'acceptance.json', result)
+        print(json.dumps({key: value for key, value in result.items() if key != 'commands'}, indent=2))
+        if not input_effect_verified:print(f'native input did not update page: {samples}',file=sys.stderr)
+        return 0 if input_effect_verified else 1
+    except Exception as error:
+        save(out / 'acceptance.json', {'passed': False, 'error': str(error), 'checks': checks, 'commands': commands})
+        print(error, file=sys.stderr)
+        return 1
+    finally:
+        if proof:
+            try:
+                request({'op': 'abort', 'proof_id': proof['proofId'], 'sequence': proof['sequence']})
+            except Exception:
+                pass
+        try:
+            destroy_owned()
+        except Exception as error:
+            print('test cleanup:', error, file=sys.stderr)
+        if server:
+            server.shutdown()
+            server.server_close()
+        for child in [daemon, foreign]:
+            if child and child.poll() is None:
+                child.terminate()
+                try:
+                    child.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    child.kill()
+                    child.wait(timeout=5)
+        daemon_log.close()
+        foreign_log.close()
+        shutil.rmtree(root)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/bin/caller/bounded_cu_task.rs
+++ b/src/bin/caller/bounded_cu_task.rs
@@ -750,7 +750,7 @@ async fn apply_cu_calls(
     Ok(())
 }
 
-fn validate_bounded_action(action: &CuAction) -> Result<(), BoundedCuTaskError> {
+pub(crate) fn validate_bounded_action(action: &CuAction) -> Result<(), BoundedCuTaskError> {
     let invalid = match action {
         CuAction::Type { text } => text.len() > BOUNDED_CU_MAX_TYPE_BYTES,
         CuAction::Key { key } => key.is_empty() || key.len() > BOUNDED_CU_MAX_KEY_BYTES,
@@ -975,7 +975,7 @@ fn parse_result(raw: &str) -> Result<(serde_json::Value, String), BoundedCuTaskE
     Ok((value, sha256(&canonical)))
 }
 
-struct UniqueJsonValueSeed;
+pub(crate) struct UniqueJsonValueSeed;
 
 impl<'de> de::DeserializeSeed<'de> for UniqueJsonValueSeed {
     type Value = serde_json::Value;
@@ -1099,7 +1099,7 @@ fn receipt_id(receipt: &BoundedCuTaskReceipt) -> Result<String, BoundedCuTaskErr
     Ok(format!("bcu-{:x}", hasher.finalize()))
 }
 
-fn action_kind(action: &CuAction) -> &'static str {
+pub(crate) fn action_kind(action: &CuAction) -> &'static str {
     match action {
         CuAction::Click { .. } => "click",
         CuAction::DoubleClick { .. } => "double_click",
@@ -1189,7 +1189,7 @@ fn redacted_action_projection(action: &CuAction) -> RedactedActionProjection<'_>
     }
 }
 
-fn action_projection_sha256(actions: &[CuAction]) -> Result<String, BoundedCuTaskError> {
+pub(crate) fn action_projection_sha256(actions: &[CuAction]) -> Result<String, BoundedCuTaskError> {
     let projection = actions
         .iter()
         .map(redacted_action_projection)
@@ -1207,7 +1207,7 @@ fn action_projection_sha256(actions: &[CuAction]) -> Result<String, BoundedCuTas
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-fn is_input(action: &CuAction) -> bool {
+pub(crate) fn is_input(action: &CuAction) -> bool {
     !matches!(
         action,
         CuAction::Screenshot | CuAction::Zoom { .. } | CuAction::Wait { .. }
@@ -1226,7 +1226,7 @@ fn sha256(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
-fn image_sha256(image: &ImageData) -> Result<String, BoundedCuTaskError> {
+pub(crate) fn image_sha256(image: &ImageData) -> Result<String, BoundedCuTaskError> {
     if image.media_type != "image/png" {
         return Err(BoundedCuTaskError::new(
             "bounded-cu-frame-media-type-invalid",

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -3335,7 +3335,12 @@ mod tests {
         let error = result.unwrap_err().to_string();
         assert!(error.contains("timed out waiting for a profile-bound CDP endpoint"));
         assert!(
-            error.contains("profile-bound CDP endpoint changed during readiness"),
+            // The same absolute deadline may expire between completed probes
+            // or inside a later probe. Scheduler timing must not dictate which
+            // honest terminal observation accompanies the required refusal.
+            error.contains("profile-bound CDP endpoint changed during readiness")
+                || error.contains("CDP target list exceeded the fixed CDP startup deadline")
+                || error.contains("CDP version endpoint exceeded the fixed CDP startup deadline"),
             "unexpected terminal observation: {error}"
         );
         assert!(

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -770,6 +770,17 @@ pub async fn ensure_managed_chromium(
     })
 }
 
+fn create_private_browser_profile(path: &Path) -> std::io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        builder.mode(0o700);
+    }
+    builder.create(path)
+}
+
 pub async fn create_workspace(
     request: CreateBrowserWorkspaceRequest,
     bus: &EventBus,
@@ -932,7 +943,7 @@ pub async fn create_workspace(
             }
         }
         None => {
-            if let Err(error) = fs::create_dir_all(&profile_dir) {
+            if let Err(error) = create_private_browser_profile(&profile_dir) {
                 let message = format!(
                     "failed to create browser workspace profile {}: {error}",
                     profile_dir.display()
@@ -3077,6 +3088,19 @@ fn now_string() -> String {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn new_browser_profiles_are_private_without_changing_existing_modes() {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("parent").join("profile");
+        create_private_browser_profile(&profile).unwrap();
+        assert_eq!(fs::metadata(&profile).unwrap().mode() & 0o777, 0o700);
+        fs::set_permissions(&profile, fs::Permissions::from_mode(0o750)).unwrap();
+        create_private_browser_profile(&profile).unwrap();
+        assert_eq!(fs::metadata(&profile).unwrap().mode() & 0o777, 0o750);
+    }
+
     use super::*;
 
     fn sample_workspace(id: &str) -> BrowserWorkspace {

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -1372,6 +1372,55 @@ async fn run_cu(client: &reqwest::Client, config: &Config, raw: &[String]) -> Re
                 call_tool(client, config, "execute_cu_actions", Value::Object(map)).await?;
             print_tool_response(response, config, output)?;
         }
+        "proof" => {
+            let args = parse_command_args(&raw[1..], &["--request"], &[])?;
+            if !args.positional.is_empty() {
+                return Err("cu proof only accepts --request JSON|@file|-".into());
+            }
+            let input = args
+                .one("--request")
+                .ok_or("cu proof requires --request JSON|@file|-")?;
+            let mut request = String::new();
+            if input == "-" {
+                std::io::stdin()
+                    .take(98_305)
+                    .read_to_string(&mut request)
+                    .map_err(|e| e.to_string())?;
+            } else if let Some(path) = input.strip_prefix('@') {
+                let meta = std::fs::symlink_metadata(path).map_err(|e| e.to_string())?;
+                if !meta.is_file() || meta.file_type().is_symlink() {
+                    return Err("proof request must be a regular non-symlink file".into());
+                }
+                let mut options = std::fs::OpenOptions::new();
+                options.read(true);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt as _;
+                    options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+                }
+                let file = options.open(path).map_err(|e| e.to_string())?;
+                if !file.metadata().map_err(|e| e.to_string())?.is_file() {
+                    return Err("proof request is not a file".into());
+                }
+                file.take(98_305)
+                    .read_to_string(&mut request)
+                    .map_err(|e| e.to_string())?;
+            } else {
+                request = input.to_owned();
+            }
+            if request.len() > 98_304 {
+                return Err("proof request exceeds 96 KiB".into());
+            }
+            // Keep raw JSON intact: the daemon rejects duplicate keys before projection.
+            let response = call_tool(
+                client,
+                config,
+                "external_cu_proof",
+                serde_json::json!({"request":request}),
+            )
+            .await?;
+            print_tool_response(response, config, None)?;
+        }
         "task" | "bounded" => {
             ensure_help(&raw[1..], help_cu_task)?;
             let args = parse_command_args(
@@ -6167,6 +6216,7 @@ fn help_cu() {
     println!(
         "Usage:\n\
   intendant ctl cu actions --actions JSON|@file|- [--target TARGET] [--observe pixels|ax|auto|none] [--annotate] [--settle MS] [--coordinate-space pixel|normalized_1000] [--output out.png]\n\
+  intendant ctl cu proof --request JSON|@file|- (begin/actions/freeze/observe/finish/close/abort/status; no model)\n\
   intendant ctl cu task TASK --mode stage|attest --attempt ID --workspace ID --display-id N --target display_N --capture-generation ID [--prior-receipt ID]\n\
   intendant ctl cu screenshot [--target TARGET] [--output out.png]\n\
   intendant ctl cu elements [--target TARGET] [--format text|json] [--full-values]\n\

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -990,10 +990,21 @@ async fn run_display(
             print_tool_response(response, config, None)?;
         }
         "create" => {
-            let args = parse_command_args(&raw[1..], &["--width", "--height"], &[])?;
+            let args = parse_command_args(
+                &raw[1..],
+                &[
+                    "--width",
+                    "--height",
+                    "--min-display-id",
+                    "--max-display-id",
+                ],
+                &[],
+            )?;
             let mut map = Map::new();
             insert_u32(&mut map, "width", args.one("--width"))?;
             insert_u32(&mut map, "height", args.one("--height"))?;
+            insert_u32(&mut map, "minimum_display_id", args.one("--min-display-id"))?;
+            insert_u32(&mut map, "maximum_display_id", args.one("--max-display-id"))?;
             let response =
                 call_tool(client, config, "create_virtual_display", Value::Object(map)).await?;
             print_tool_response(response, config, None)?;
@@ -6121,7 +6132,7 @@ fn help_display() {
     println!(
         "Usage:\n\
   intendant ctl display list\n\
-  intendant ctl display create [--width N] [--height N]\n\
+  intendant ctl display create [--width N] [--height N] [--min-display-id N --max-display-id N]\n\
   intendant ctl display destroy DISPLAY_ID CAPTURE_GENERATION [--note TEXT]\n\
   intendant ctl display status [--target TARGET]\n\
   intendant ctl display frames [--stream NAME] [--count N]\n\

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -2753,6 +2753,11 @@ pub enum ControlMsg {
         width: Option<u32>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         height: Option<u32>,
+        /// Optional inclusive allocation pool; both bounds must be present.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        minimum_display_id: Option<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        maximum_display_id: Option<u32>,
     },
     /// Destroy one exact daemon-owned virtual-display generation. Numeric
     /// X11 display ids can be reused, so both the id and the opaque
@@ -5314,6 +5319,8 @@ mod tests {
             request_id: Some("vdc-lossless".to_string()),
             width: Some(1280),
             height: Some(720),
+            minimum_display_id: None,
+            maximum_display_id: None,
         }));
         bus.send(AppEvent::DisplayCaptureLost {
             display_id: 99,
@@ -5332,13 +5339,15 @@ mod tests {
             Some(AppEvent::UserDisplayGranted { display_id: 99, .. })
         ));
         assert!(matches!(
-            intents.recv().await,
-            Some(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
-                request_id: Some(request_id),
-                width: Some(1280),
-                height: Some(720),
-            })) if request_id == "vdc-lossless"
-        ));
+                    intents.recv().await,
+                    Some(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+                        request_id: Some(request_id),
+                        width: Some(1280),
+                        height: Some(720),
+                    minimum_display_id: None,
+                    maximum_display_id: None,
+        })) if request_id == "vdc-lossless"
+                ));
         assert!(matches!(
             intents.recv().await,
             Some(AppEvent::DisplayCaptureLost { display_id: 99, .. })
@@ -6973,7 +6982,9 @@ mod tests {
             ControlMsg::CreateVirtualDisplay {
                 request_id: None,
                 width: None,
-                height: None
+                height: None,
+                minimum_display_id: None,
+                maximum_display_id: None,
             }
         ));
 
@@ -6984,20 +6995,24 @@ mod tests {
             ControlMsg::CreateVirtualDisplay {
                 request_id: None,
                 width: Some(1280),
-                height: Some(800)
+                height: Some(800),
+                minimum_display_id: None,
+                maximum_display_id: None,
             }
         ));
 
         let json = r#"{"action":"create_virtual_display","request_id":"vdc-abc","width":1024,"height":768}"#;
         let msg: ControlMsg = serde_json::from_str(json).unwrap();
         assert!(matches!(
-            msg,
-            ControlMsg::CreateVirtualDisplay {
-                request_id: Some(ref request_id),
-                width: Some(1024),
-                height: Some(768)
-            } if request_id == "vdc-abc"
-        ));
+                    msg,
+                    ControlMsg::CreateVirtualDisplay {
+                        request_id: Some(ref request_id),
+                        width: Some(1024),
+                        height: Some(768),
+                    minimum_display_id: None,
+                    maximum_display_id: None,
+        } if request_id == "vdc-abc"
+                ));
         let serialized = serde_json::to_value(&msg).unwrap();
         assert_eq!(serialized["request_id"], "vdc-abc");
     }

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3371,14 +3371,20 @@ pub fn spawn_user_display_listener(
                     request_id,
                     width,
                     height,
+                    minimum_display_id,
+                    maximum_display_id,
                 }) => {
                     virtual_display::create_virtual_display(
                         &bus,
                         &session_registry,
                         frame_registry.clone(),
                         &mut virtual_display_guards,
-                        width,
-                        height,
+                        virtual_display::VirtualDisplayCreateOptions {
+                            width,
+                            height,
+                            minimum_display_id,
+                            maximum_display_id,
+                        },
                         request_id,
                     )
                     .await;

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1848,6 +1848,8 @@ mod tests {
                 request_id: None,
                 width: Some(1280),
                 height: Some(800),
+                minimum_display_id: None,
+                maximum_display_id: None,
             },
         )
         .await;

--- a/src/bin/caller/mcp/facade/registry.rs
+++ b/src/bin/caller/mcp/facade/registry.rs
@@ -884,6 +884,8 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
         flags: &[
             flag!("width", "width", U64, "width px (default 1920)"),
             flag!("height", "height", U64, "height px (default 1080)"),
+            flag!("min-display-id", "minimum_display_id", U64, "inclusive allocation pool minimum (99..199; supply both bounds)"),
+            flag!("max-display-id", "maximum_display_id", U64, "inclusive allocation pool maximum (99..199)"),
         ],
         help: "Create a virtual display",
     },

--- a/src/bin/caller/mcp/facade/registry.rs
+++ b/src/bin/caller/mcp/facade/registry.rs
@@ -844,6 +844,11 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
         help: "Execute a JSON array of computer-use actions",
     },
     CommandSpec {
+        path: &["cu", "proof"], lane: RiskLane::Act, tool: "external_cu_proof", seed: "{}",
+        positionals: &[], flags: &[flag!("request", "request", Str, "duplicate-key-safe proof request JSON")],
+        help: "Drive a bounded, model-free external proof session",
+    },
+    CommandSpec {
         path: &["cu", "task"],
         lane: RiskLane::Act,
         tool: "run_bounded_cu_task",

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -73,6 +73,7 @@ pub(crate) use tools_ask::{
 #[cfg(test)]
 pub(crate) use tools_ask::unregister_pending_ask;
 mod tools_bounded_cu;
+pub(crate) use tools_bounded_cu::ExternalCuProofParams;
 mod tools_codex_cloud;
 mod tools_display;
 mod tools_events;
@@ -998,6 +999,13 @@ impl IntendantServer {
                 let params = parse_params::<ReleaseBrowserWorkspaceParams>(args)?;
                 Ok(text_tool_result(
                     self.release_browser_workspace(params).await,
+                ))
+            }
+            "external_cu_proof" => {
+                let Parameters(params) = parse_params::<ExternalCuProofParams>(args)?;
+                Ok(text_tool_result(
+                    self.external_cu_proof_as_caller(params, caller, &actor)
+                        .await,
                 ))
             }
             "run_bounded_cu_task" => {

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -93,13 +93,14 @@ pub(crate) fn fission_tool(name: &str) -> bool {
 /// codex thread-action waits (20 s) and the remaining peer round
 /// trips (sub-second lookups under `PEER_MCP_TIMEOUT`'s transport
 /// bound — a bound is not a hold).
-pub(crate) const MCP_HELD_POST_TOOLS: [&str; 9] = [
+pub(crate) const MCP_HELD_POST_TOOLS: [&str; 10] = [
     "ask_user",
     "request_user_display",
     "spawn_live_audio",
     "fission_control",
     "execute_cu_actions",
     "run_bounded_cu_task",
+    "external_cu_proof",
     "peer_execute_cu_actions",
     "events",
     "remote_command",
@@ -457,7 +458,8 @@ pub(crate) fn mcp_tool_operation(name: &str) -> crate::peer::access_policy::Peer
         | "revoke_user_display"
         | "request_shared_view_input"
         | "execute_cu_actions"
-        | "run_bounded_cu_task" => PeerOperation::DisplayInput,
+        | "run_bounded_cu_task"
+        | "external_cu_proof" => PeerOperation::DisplayInput,
         // Browser workspaces, live audio, autonomy/verbosity, lifecycle, and
         // controller-restart orchestration are runtime-control surfaces.
         "create_browser_workspace"
@@ -900,6 +902,7 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
             DestroyVirtualDisplayParams
         ),
     );
+    push("external_cu_proof", manual_http_tool_definition!("external_cu_proof", "Drive an owner-bound proof session using explicit actions, with no model calls. The duplicate-key-safe request commands are begin/actions/freeze/observe/finish/close/abort/status. Sessions retain exact display exclusion, limits, actor binding and cleanup across calls. finish records external claims, never independent policy approval. Returns private PNG observations and a versioned execution receipt.", ExternalCuProofParams));
     push(
         "run_bounded_cu_task",
         manual_http_tool_definition!(

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -629,6 +629,11 @@ pub struct CreateVirtualDisplayParams {
     /// Optional height in pixels (default 1080; same clamping).
     #[serde(default)]
     pub height: Option<u32>,
+    /// Inclusive subset of the managed pool (99..199). Supply both bounds or neither.
+    #[serde(default)]
+    pub minimum_display_id: Option<u32>,
+    #[serde(default)]
+    pub maximum_display_id: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/src/bin/caller/mcp/tools_bounded_cu.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu.rs
@@ -2,7 +2,10 @@
 //! proof capture. This is intentionally separate from general task dispatch.
 
 use super::*;
+
+mod external;
 use async_trait::async_trait;
+pub use external::ExternalCuProofParams;
 
 use crate::bounded_cu_task::{
     remember_issued_stage_receipt, run_bounded_cu_task_until as execute_bounded_cu_task_until,
@@ -387,29 +390,20 @@ impl IntendantServer {
         }
     }
 
-    async fn run_bounded_cu_task_inner(
+    async fn prepare_proof_executor(
         &self,
-        params: RunBoundedCuTaskParams,
-        deadline: tokio::time::Instant,
-    ) -> Result<crate::bounded_cu_task::BoundedCuTaskReceipt, BoundedCuTaskError> {
-        let request = BoundedCuTaskRequest {
-            mode: params.mode,
-            attempt_id: params.attempt_id.clone(),
-            workspace_id: params.workspace_id.clone(),
-            display_id: params.display_id,
-            display_target: params.display_target.clone(),
-            capture_generation: params.capture_generation.clone(),
-            task: params.task.clone(),
-            prior_receipt_id: params.prior_receipt_id.clone(),
-            prior_transcript_event_count: None,
-            prior_transcript_sha256: None,
-            observation_sha256: None,
-            prior_completed_at: None,
-        };
-        validate_bounded_cu_task_request(&request)?;
+        params: &RunBoundedCuTaskParams,
+    ) -> Result<
+        (
+            NativeBoundedCuExecutor,
+            crate::project::ComputerUseConfig,
+            std::sync::Arc<tempfile::TempDir>,
+        ),
+        BoundedCuTaskError,
+    > {
         let display_access =
             crate::computer_use::acquire_virtual_display_exclusive(params.display_id).await;
-        validate_resource_binding(&params, &self.bus).await?;
+        validate_resource_binding(params, &self.bus).await?;
         let (cu_config, session_registry, action_counter) = {
             let state = self.state.read().await;
             (
@@ -479,14 +473,9 @@ impl IntendantServer {
                 false,
             ));
         }
-        let mut provider =
-            crate::provider::select_bounded_cu_provider(&cu_config).map_err(|error| {
-                BoundedCuTaskError::new("bounded-cu-provider-unavailable", error.to_string(), true)
-            })?;
-        provider.set_cu_display(dimensions);
         let scratch = std::sync::Arc::new(create_private_scratch()?);
         validate_private_scratch(scratch.path())?;
-        let mut executor = NativeBoundedCuExecutor {
+        let executor = NativeBoundedCuExecutor {
             target,
             backend: DisplayBackend::from_config(&cu_config.backend),
             scratch_dir: scratch.path().to_path_buf(),
@@ -501,6 +490,35 @@ impl IntendantServer {
             pending_safety_releases: Vec::new(),
             in_flight_action: None,
         };
+        Ok((executor, cu_config, scratch))
+    }
+
+    async fn run_bounded_cu_task_inner(
+        &self,
+        params: RunBoundedCuTaskParams,
+        deadline: tokio::time::Instant,
+    ) -> Result<crate::bounded_cu_task::BoundedCuTaskReceipt, BoundedCuTaskError> {
+        let request = BoundedCuTaskRequest {
+            mode: params.mode,
+            attempt_id: params.attempt_id.clone(),
+            workspace_id: params.workspace_id.clone(),
+            display_id: params.display_id,
+            display_target: params.display_target.clone(),
+            capture_generation: params.capture_generation.clone(),
+            task: params.task.clone(),
+            prior_receipt_id: params.prior_receipt_id.clone(),
+            prior_transcript_event_count: None,
+            prior_transcript_sha256: None,
+            observation_sha256: None,
+            prior_completed_at: None,
+        };
+        validate_bounded_cu_task_request(&request)?;
+        let (mut executor, cu_config, scratch) = self.prepare_proof_executor(&params).await?;
+        let mut provider =
+            crate::provider::select_bounded_cu_provider(&cu_config).map_err(|error| {
+                BoundedCuTaskError::new("bounded-cu-provider-unavailable", error.to_string(), true)
+            })?;
+        provider.set_cu_display(executor.proof_session.resolution());
         let task_result =
             execute_bounded_cu_task_until(provider.as_ref(), &mut executor, request, deadline)
                 .await;

--- a/src/bin/caller/mcp/tools_bounded_cu/external.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu/external.rs
@@ -1,0 +1,1011 @@
+//! Provider-free, owner-bound proof sessions. The worker, not an HTTP request,
+//! owns display exclusion and cancellation cleanup across external agent turns.
+use super::*;
+use crate::access::actor::{ActorBinding, ActorKind};
+use crate::bounded_cu_task::{
+    action_kind, action_projection_sha256, image_sha256, is_input, validate_bounded_action,
+    UniqueJsonValueSeed,
+};
+use base64::Engine as _;
+use serde::de::DeserializeSeed as _;
+use serde_json::{json, Value};
+use sha2::{Digest as _, Sha256};
+use std::collections::HashMap;
+use std::sync::{Mutex as StdMutex, OnceLock};
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, oneshot};
+
+const PROFILE: &str = "intendant-external-cu-proof-v1";
+const MAX_SESSIONS: usize = 8;
+const STAGE_SECONDS: u64 = 180;
+const FROZEN_SECONDS: u64 = 45;
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalCuProofParams {
+    /// Duplicate-key-safe JSON command. Operations: begin, actions, freeze,
+    /// observe, finish, close, abort, status. No provider or model is selected.
+    pub request: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+enum Request {
+    Begin {
+        attempt_id: String,
+        workspace_id: String,
+        display_id: u32,
+        display_target: String,
+        capture_generation: String,
+        job_sha256: String,
+    },
+    Actions {
+        proof_id: String,
+        sequence: u64,
+        actions_json: String,
+    },
+    Freeze {
+        proof_id: String,
+        sequence: u64,
+    },
+    Observe {
+        proof_id: String,
+        sequence: u64,
+        pre_observation_sha256: String,
+    },
+    Finish {
+        proof_id: String,
+        sequence: u64,
+        observation_sha256: String,
+        claims_json: String,
+    },
+    Close {
+        proof_id: String,
+        sequence: u64,
+    },
+    Abort {
+        proof_id: String,
+        sequence: u64,
+    },
+    Status {
+        proof_id: String,
+    },
+}
+impl Request {
+    fn id(&self) -> Option<&str> {
+        match self {
+            Self::Begin { .. } => None,
+            Self::Actions { proof_id, .. }
+            | Self::Freeze { proof_id, .. }
+            | Self::Observe { proof_id, .. }
+            | Self::Finish { proof_id, .. }
+            | Self::Close { proof_id, .. }
+            | Self::Abort { proof_id, .. }
+            | Self::Status { proof_id } => Some(proof_id),
+        }
+    }
+    fn sequence(&self) -> Option<u64> {
+        match self {
+            Self::Begin { .. } | Self::Status { .. } => None,
+            Self::Actions { sequence, .. }
+            | Self::Freeze { sequence, .. }
+            | Self::Observe { sequence, .. }
+            | Self::Finish { sequence, .. }
+            | Self::Close { sequence, .. }
+            | Self::Abort { sequence, .. } => Some(*sequence),
+        }
+    }
+}
+fn err(code: &'static str, message: &str) -> BoundedCuTaskError {
+    BoundedCuTaskError::new(code, message, false)
+}
+fn digest(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+fn hash_value(domain: &str, value: &Value) -> String {
+    let mut bytes = domain.as_bytes().to_vec();
+    bytes.push(0);
+    bytes.extend(serde_json::to_vec(value).expect("JSON value"));
+    digest(&bytes)
+}
+fn now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+fn sha_ok(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+fn unique_json(raw: &str, maximum: usize) -> Result<Value, BoundedCuTaskError> {
+    if raw.is_empty() || raw.len() > maximum {
+        return Err(err(
+            "external-proof-input-size",
+            "proof JSON exceeds its fixed byte limit",
+        ));
+    }
+    let mut de = serde_json::Deserializer::from_str(raw);
+    let value = UniqueJsonValueSeed.deserialize(&mut de).map_err(|_| {
+        err(
+            "external-proof-json",
+            "proof input must be duplicate-key-free JSON",
+        )
+    })?;
+    de.end()
+        .map_err(|_| err("external-proof-json", "proof input contains trailing data"))?;
+    Ok(value)
+}
+fn parse(raw: &str) -> Result<Request, BoundedCuTaskError> {
+    serde_json::from_value(unique_json(raw, 96 * 1024)?)
+        .map_err(|_| err("external-proof-command", "unknown proof command or fields"))
+}
+fn actor_record(actor: &ActorBinding) -> Value {
+    // Tenant projection, not serialization of the evolving ActorBinding seam.
+    json!({"kind": actor.kind.as_str(), "principalId": actor.principal_id, "sessionId": actor.session_id})
+}
+fn binding(params: &RunBoundedCuTaskParams, job: &str) -> Value {
+    json!({"attemptId":params.attempt_id,"workspaceId":params.workspace_id,
+        "displayId":params.display_id,"displayTarget":params.display_target,
+        "captureGeneration":params.capture_generation,"jobSha256":job})
+}
+fn actions(raw: &str) -> Result<Vec<CuAction>, BoundedCuTaskError> {
+    let value = unique_json(raw, 64 * 1024)?;
+    let values = value
+        .as_array()
+        .ok_or_else(|| err("external-proof-actions", "actions must be an array"))?;
+    if values.is_empty() || values.len() > 16 {
+        return Err(err(
+            "external-proof-actions",
+            "a batch requires 1..16 actions",
+        ));
+    }
+    let mut out = Vec::new();
+    for value in values {
+        let action: CuAction = serde_json::from_value(value.clone())
+            .map_err(|_| err("external-proof-action", "invalid action"))?;
+        // Reject unknown fields rather than silently discarding instructions.
+        let projected = serde_json::to_value(&action).expect("CU action");
+        let supplied = value
+            .as_object()
+            .ok_or_else(|| err("external-proof-action", "action must be an object"))?;
+        let known = projected.as_object().expect("CU action object");
+        if supplied.keys().any(|key| !known.contains_key(key)) {
+            return Err(err("external-proof-action", "unknown action field"));
+        }
+        if matches!(
+            action,
+            CuAction::Paste { .. }
+                | CuAction::MouseDown { .. }
+                | CuAction::MouseUp { .. }
+                | CuAction::Zoom { .. }
+        ) {
+            return Err(err(
+                "external-proof-action-forbidden",
+                "clipboard, split input edges, and cropped frames are forbidden in proof sessions",
+            ));
+        }
+        validate_bounded_action(&action)?;
+        out.push(action);
+    }
+    Ok(out)
+}
+fn frame(outcome: &BoundedCuActionOutcome) -> Result<Value, BoundedCuTaskError> {
+    if outcome.screenshot.data.len() > 12 * 1024 * 1024 {
+        return Err(err("external-proof-frame-size", "proof PNG exceeds limit"));
+    }
+    let sha = image_sha256(&outcome.screenshot)?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(&outcome.screenshot.data)
+        .map_err(|_| err("external-proof-frame", "invalid PNG encoding"))?;
+    if bytes.len() < 33
+        || &bytes[12..16] != b"IHDR"
+        || base64::engine::general_purpose::STANDARD.encode(&bytes) != outcome.screenshot.data
+    {
+        return Err(err("external-proof-frame", "invalid canonical PNG frame"));
+    }
+    let width = u32::from_be_bytes(bytes[16..20].try_into().expect("PNG width"));
+    let height = u32::from_be_bytes(bytes[20..24].try_into().expect("PNG height"));
+    if width == 0 || height == 0 || width > 4096 || height > 4096 {
+        return Err(err("external-proof-frame", "invalid proof geometry"));
+    }
+    Ok(
+        json!({"sha256":sha,"byteLength":bytes.len(),"width":width,"height":height,"pngBase64":outcome.screenshot.data}),
+    )
+}
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Phase {
+    Stage,
+    Frozen,
+    Observed,
+    Finished,
+}
+impl Phase {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Stage => "stage",
+            Self::Frozen => "frozen",
+            Self::Observed => "observed",
+            Self::Finished => "finished",
+        }
+    }
+}
+struct Proof {
+    id: String,
+    binding: Value,
+    actor: Value,
+    phase: Phase,
+    sequence: u64,
+    started: Instant,
+    started_at: String,
+    frozen_at: Option<String>,
+    observed_at: Option<String>,
+    action_count: u64,
+    input_count: u64,
+    events: Vec<Value>,
+    frame: Value,
+    stage_digest: Option<String>,
+    pre_observation: Option<String>,
+    receipt: Option<Value>,
+}
+impl Proof {
+    fn new(
+        id: String,
+        binding: Value,
+        actor: Value,
+        started: Instant,
+        started_at: String,
+        initial: Value,
+    ) -> Self {
+        let mut proof = Self {
+            id,
+            binding,
+            actor,
+            phase: Phase::Stage,
+            sequence: 0,
+            started,
+            started_at,
+            frozen_at: None,
+            observed_at: None,
+            action_count: 0,
+            input_count: 0,
+            events: Vec::new(),
+            frame: initial,
+            stage_digest: None,
+            pre_observation: None,
+            receipt: None,
+        };
+        proof.event(
+            "initial_frame",
+            json!({"frameSha256":proof.frame["sha256"]}),
+        );
+        proof
+    }
+    fn event(&mut self, kind: &str, detail: Value) {
+        self.events
+            .push(json!({"sequence":self.events.len(),"kind":kind,"detail":detail}));
+    }
+    fn snapshot(&self) -> Value {
+        json!({"ok":true,"profile":PROFILE,"proofId":self.id,"sequence":self.sequence,"binding":self.binding,"actor":self.actor,
+            "phase":self.phase.name(),"frame":self.frame,"receipt":self.receipt})
+    }
+    fn check_sequence(&self, request: &Request) -> Result<(), BoundedCuTaskError> {
+        if request.sequence().is_some_and(|seq| seq != self.sequence) {
+            return Err(err(
+                "external-proof-sequence",
+                "stale or replayed sequence; no action executed",
+            ));
+        }
+        Ok(())
+    }
+    fn require_phase(&self, phase: Phase) -> Result<(), BoundedCuTaskError> {
+        if self.phase != phase {
+            return Err(err(
+                "external-proof-phase",
+                "operation is forbidden in the current proof phase",
+            ));
+        }
+        Ok(())
+    }
+    fn make_receipt(&self, claims: &str) -> Result<Value, BoundedCuTaskError> {
+        let completed = now();
+        if completed < self.started_at {
+            return Err(err("external-proof-clock", "wall clock moved backwards"));
+        }
+        let mut image = self.frame.clone();
+        image.as_object_mut().expect("frame").remove("pngBase64");
+        let mut receipt = json!({"schemaVersion":2,"profile":PROFILE,"proofId":self.id,
+            "binding":self.binding,"actor":self.actor,
+            "execution":{"kind":"external-actions","internalModelCalls":0,"claimsAuthority":"external-caller","grantsSubmissionAuthority":false},
+            "startedAt":self.started_at,"frozenAt":self.frozen_at,"observedAt":self.observed_at,"completedAt":completed,
+            "elapsedMs":self.started.elapsed().as_millis() as u64,"actionCount":self.action_count,"inputEventCount":self.input_count,
+            "postObservationInputEventCount":0,"stageTranscriptSha256":self.stage_digest,
+            "preObservationSha256":self.pre_observation,"observation":image,
+            "transcript":self.events,"transcriptSha256":hash_value("intendant-external-cu-transcript-v1",&json!(self.events)),
+            "claimsJson":claims,"claimsSha256":digest(claims.as_bytes())});
+        let id = format!(
+            "ecup-receipt:{}",
+            hash_value("intendant-external-cu-receipt-v1", &receipt)
+        );
+        receipt["receiptId"] = json!(id);
+        Ok(receipt)
+    }
+}
+
+struct Message {
+    request: Request,
+    reply: oneshot::Sender<Result<Value, BoundedCuTaskError>>,
+}
+#[derive(Clone)]
+struct Handle {
+    actor: ActorBinding,
+    display: u32,
+    attempt: String,
+    tx: mpsc::Sender<Message>,
+}
+fn registry() -> &'static StdMutex<HashMap<String, Handle>> {
+    static REGISTRY: OnceLock<StdMutex<HashMap<String, Handle>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+struct Registration(String);
+impl Drop for Registration {
+    fn drop(&mut self) {
+        if let Ok(mut registry) = registry().lock() {
+            registry.remove(&self.0);
+        }
+    }
+}
+async fn cleanup(executor: NativeBoundedCuExecutor) -> Result<(), BoundedCuTaskError> {
+    let mut executor = executor;
+    let release = executor.release_pending_input_edges().await;
+    let bound = validate_resource_binding(&executor.params, &executor.bus).await;
+    let live = executor.validate_proof_session_liveness().await;
+    let scratch = std::sync::Arc::clone(&executor.scratch_guard);
+    drop(executor);
+    let scratch_result = std::sync::Arc::try_unwrap(scratch)
+        .map_err(|_| {
+            err(
+                "external-proof-cleanup-pending",
+                "native work still owns private scratch",
+            )
+        })?
+        .close()
+        .map_err(|_| {
+            err(
+                "external-proof-cleanup-failed",
+                "private proof scratch could not be removed",
+            )
+        });
+    release?;
+    bound?;
+    live?;
+    scratch_result
+}
+fn validate_step(proof: &Proof, request: &Request) -> Result<Vec<CuAction>, BoundedCuTaskError> {
+    proof.check_sequence(request)?;
+    match request {
+        Request::Actions { actions_json, .. } => {
+            proof.require_phase(Phase::Stage)?;
+            let actions = actions(actions_json)?;
+            if proof.action_count + actions.len() as u64 > 64 {
+                return Err(err(
+                    "external-proof-action-limit",
+                    "session action limit is 64",
+                ));
+            }
+            Ok(actions)
+        }
+        Request::Freeze { .. } => {
+            proof.require_phase(Phase::Stage)?;
+            Ok(vec![])
+        }
+        Request::Observe {
+            pre_observation_sha256,
+            ..
+        } => {
+            proof.require_phase(Phase::Frozen)?;
+            if !sha_ok(pre_observation_sha256) {
+                return Err(err(
+                    "external-proof-observation",
+                    "pre-observation digest is invalid",
+                ));
+            }
+            Ok(vec![])
+        }
+        Request::Finish {
+            observation_sha256,
+            claims_json,
+            ..
+        } => {
+            proof.require_phase(Phase::Observed)?;
+            if !sha_ok(observation_sha256) || proof.frame["sha256"] != *observation_sha256 {
+                return Err(err(
+                    "external-proof-observation",
+                    "claims do not bind the exact issued observation",
+                ));
+            }
+            if !unique_json(claims_json, 16 * 1024)?.is_object() {
+                return Err(err(
+                    "external-proof-claims",
+                    "external claims must be a JSON object",
+                ));
+            }
+            Ok(vec![])
+        }
+        Request::Close { .. } => {
+            proof.require_phase(Phase::Finished)?;
+            Ok(vec![])
+        }
+        Request::Status { .. } | Request::Abort { .. } => Ok(vec![]),
+        Request::Begin { .. } => Err(err("external-proof-command", "begin is not a continuation")),
+    }
+}
+async fn step(
+    proof: &mut Proof,
+    executor: &mut NativeBoundedCuExecutor,
+    request: &Request,
+    actions: Vec<CuAction>,
+) -> Result<(), BoundedCuTaskError> {
+    match request {
+        Request::Actions { .. } => {
+            for action in actions {
+                // Prevalidated the entire batch before executing even its first action.
+                let outcome = executor.execute(std::slice::from_ref(&action)).await?;
+                if outcome.statuses.len() != 1 || outcome.statuses[0] == CuActionStatus::Failed {
+                    return Err(err("external-proof-action-failed", "native action failed"));
+                }
+                proof.frame = frame(&outcome)?;
+                proof.action_count += 1;
+                proof.input_count += u64::from(is_input(&action));
+                proof.event("action",json!({"kind":action_kind(&action),"projectionSha256":action_projection_sha256(std::slice::from_ref(&action))?,
+                    "status":outcome.statuses[0].label(),"input":is_input(&action),"frameSha256":proof.frame["sha256"]}));
+            }
+        }
+        Request::Freeze { .. } => {
+            executor.release_pending_input_edges().await?;
+            proof.phase = Phase::Frozen;
+            proof.frozen_at = Some(now());
+            proof.event("freeze", json!({"frameSha256":proof.frame["sha256"]}));
+            proof.stage_digest = Some(hash_value(
+                "intendant-external-cu-stage-v1",
+                &json!(proof.events),
+            ));
+        }
+        Request::Observe {
+            pre_observation_sha256,
+            ..
+        } => {
+            executor.initial_frame_not_before = Some(Instant::now());
+            let outcome = executor.execute(&[CuAction::Screenshot]).await?;
+            proof.frame = frame(&outcome)?;
+            proof.phase = Phase::Observed;
+            proof.observed_at = Some(now());
+            proof.pre_observation = Some(pre_observation_sha256.clone());
+            proof.event("observation",json!({"frameSha256":proof.frame["sha256"],"preObservationSha256":pre_observation_sha256}));
+        }
+        Request::Finish { claims_json, .. } => {
+            proof.event("external_claims",json!({"claimsSha256":digest(claims_json.as_bytes()),"frameSha256":proof.frame["sha256"]}));
+            proof.receipt = Some(proof.make_receipt(claims_json)?);
+            proof.phase = Phase::Finished;
+        }
+        _ => {}
+    }
+    validate_resource_binding(&executor.params, &executor.bus).await?;
+    executor.validate_proof_session_liveness().await?;
+    if !matches!(request, Request::Status { .. }) {
+        proof.sequence += 1;
+    }
+    Ok(())
+}
+async fn worker(
+    server: IntendantServer,
+    id: String,
+    params: RunBoundedCuTaskParams,
+    job: String,
+    actor: ActorBinding,
+    mut rx: mpsc::Receiver<Message>,
+    begin_reply: oneshot::Sender<Result<Value, BoundedCuTaskError>>,
+) {
+    let _registration = Registration(id.clone());
+    let start = Instant::now();
+    let started_at = now();
+    let mut deadline = tokio::time::Instant::now() + Duration::from_secs(STAGE_SECONDS);
+    let preparation = tokio::time::timeout(
+        Duration::from_secs(20),
+        server.prepare_proof_executor(&params),
+    )
+    .await;
+    let (mut executor, _, scratch) = match preparation {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => {
+            let _ = begin_reply.send(Err(error));
+            return;
+        }
+        Err(_) => {
+            let _ = begin_reply.send(Err(err(
+                "external-proof-setup-timeout",
+                "proof setup exceeded 20 seconds",
+            )));
+            return;
+        }
+    };
+    drop(scratch); // Executor and any in-flight native operation retain this guard.
+    let initial =
+        match tokio::time::timeout_at(deadline, executor.execute(&[CuAction::Screenshot])).await {
+            Ok(Ok(outcome)) => frame(&outcome),
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(err("external-proof-expired", "proof deadline expired")),
+        };
+    let initial = match initial {
+        Ok(frame) => frame,
+        Err(error) => {
+            let _ = cleanup(executor).await;
+            let _ = begin_reply.send(Err(error));
+            return;
+        }
+    };
+    let mut proof = Proof::new(
+        id,
+        binding(&params, &job),
+        actor_record(&actor),
+        start,
+        started_at,
+        initial,
+    );
+    if begin_reply.send(Ok(proof.snapshot())).is_err() {
+        let _ = cleanup(executor).await;
+        return;
+    }
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        let message = match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Ok(Some(message)) => message,
+            _ => break,
+        };
+        if tokio::time::Instant::now() >= deadline {
+            let _ = message
+                .reply
+                .send(Err(err("external-proof-expired", "proof deadline expired")));
+            break;
+        }
+        let actions = match validate_step(&proof, &message.request) {
+            Ok(value) => value,
+            Err(error) => {
+                let _ = message.reply.send(Err(error));
+                continue;
+            }
+        };
+        if matches!(
+            message.request,
+            Request::Close { .. } | Request::Abort { .. }
+        ) {
+            let aborted = matches!(message.request, Request::Abort { .. });
+            let result=cleanup(executor).await.map(|()|json!({"ok":true,"profile":PROFILE,"proofId":proof.id,
+                "sequence":proof.sequence+1,"closed":true,"aborted":aborted,"cleanupComplete":true,
+                "receiptId":if aborted {Value::Null}else{proof.receipt.as_ref().map(|r|r["receiptId"].clone()).unwrap_or(Value::Null)}}));
+            let _ = message.reply.send(result);
+            return;
+        }
+        let result = tokio::time::timeout_at(
+            deadline,
+            step(&mut proof, &mut executor, &message.request, actions),
+        )
+        .await;
+        match result {
+            Ok(Ok(())) => {
+                if tokio::time::Instant::now() >= deadline {
+                    let _ = cleanup(executor).await;
+                    let _ = message.reply.send(Err(err(
+                        "external-proof-expired",
+                        "proof deadline expired before completion",
+                    )));
+                    return;
+                }
+                if matches!(message.request, Request::Freeze { .. }) {
+                    deadline = tokio::time::Instant::now() + Duration::from_secs(FROZEN_SECONDS);
+                }
+                // Losing a reply never replays input. The next caller can inspect the sequence.
+                let _ = message.reply.send(Ok(proof.snapshot()));
+            }
+            Ok(Err(error)) => {
+                let _ = cleanup(executor).await;
+                let _ = message.reply.send(Err(error));
+                return;
+            }
+            Err(_) => {
+                let _ = cleanup(executor).await;
+                let _ = message.reply.send(Err(err(
+                    "external-proof-expired",
+                    "proof deadline expired; attempt must not be replayed",
+                )));
+                return;
+            }
+        }
+    }
+    // Abandoned sessions expire even when no client reconnects. The native
+    // executor retains exclusion through any detached OS work during Drop.
+    let _ = cleanup(executor).await;
+}
+impl IntendantServer {
+    #[tool(
+        description = "Drive an owner-bound proof session using explicit actions, with no model calls. The duplicate-key-safe request commands are begin/actions/freeze/observe/finish/close/abort/status. Sessions retain exact display exclusion, limits, actor binding and cleanup across calls. finish records external claims, never independent policy approval. Returns private PNG observations and a versioned execution receipt."
+    )]
+    pub(crate) async fn external_cu_proof(
+        &self,
+        Parameters(params): Parameters<ExternalCuProofParams>,
+    ) -> String {
+        self.external_cu_proof_as_caller(
+            params,
+            ToolCallerTrust::OwnerSurface,
+            &ActorBinding::local_process(None),
+        )
+        .await
+    }
+    pub(crate) async fn external_cu_proof_as_caller(
+        &self,
+        params: ExternalCuProofParams,
+        caller: ToolCallerTrust,
+        actor: &ActorBinding,
+    ) -> String {
+        let result = self.external_proof_dispatch(params, caller, actor).await;
+        match result {Ok(value)=>value.to_string(),Err(error)=>json!({"ok":false,"error":{"code":error.code,"message":error.message,"retryable":error.retryable}}).to_string()}
+    }
+    async fn external_proof_dispatch(
+        &self,
+        params: ExternalCuProofParams,
+        caller: ToolCallerTrust,
+        actor: &ActorBinding,
+    ) -> Result<Value, BoundedCuTaskError> {
+        require_owner_surface(caller)?;
+        if actor.kind == ActorKind::Unattributed {
+            return Err(err(
+                "external-proof-actor",
+                "proof sessions require a gate-resolved actor",
+            ));
+        }
+        let request = parse(&params.request)?;
+        let (reply, receiver) = oneshot::channel();
+        if let Request::Begin {
+            attempt_id,
+            workspace_id,
+            display_id,
+            display_target,
+            capture_generation,
+            job_sha256,
+        } = request
+        {
+            if !sha_ok(&job_sha256) || display_id == 0 {
+                return Err(err(
+                    "external-proof-binding",
+                    "a job digest and non-user virtual display are required",
+                ));
+            }
+            let params = RunBoundedCuTaskParams {
+                mode: crate::bounded_cu_task::BoundedCuTaskMode::Stage,
+                attempt_id,
+                workspace_id,
+                display_id,
+                display_target,
+                capture_generation,
+                task: job_sha256.clone(),
+                prior_receipt_id: None,
+            };
+            validate_bounded_cu_task_request(&BoundedCuTaskRequest {
+                mode: params.mode,
+                attempt_id: params.attempt_id.clone(),
+                workspace_id: params.workspace_id.clone(),
+                display_id: params.display_id,
+                display_target: params.display_target.clone(),
+                capture_generation: params.capture_generation.clone(),
+                task: params.task.clone(),
+                prior_receipt_id: None,
+                prior_transcript_event_count: None,
+                prior_transcript_sha256: None,
+                observation_sha256: None,
+                prior_completed_at: None,
+            })?;
+            let id = format!("ecup-{}", Uuid::new_v4().simple());
+            let (tx, rx) = mpsc::channel(1);
+            {
+                let mut map = registry()
+                    .lock()
+                    .map_err(|_| err("external-proof-registry", "proof registry unavailable"))?;
+                if map.len() >= MAX_SESSIONS
+                    || map
+                        .values()
+                        .any(|h| h.display == params.display_id || h.attempt == params.attempt_id)
+                {
+                    return Err(err(
+                        "external-proof-busy",
+                        "display, attempt, or proof capacity already reserved",
+                    ));
+                }
+                map.insert(
+                    id.clone(),
+                    Handle {
+                        actor: actor.clone(),
+                        display: params.display_id,
+                        attempt: params.attempt_id.clone(),
+                        tx,
+                    },
+                );
+            }
+            tokio::spawn(worker(
+                self.clone(),
+                id,
+                params,
+                job_sha256,
+                actor.clone(),
+                rx,
+                reply,
+            ));
+        } else {
+            let handle = {
+                let map = registry()
+                    .lock()
+                    .map_err(|_| err("external-proof-registry", "proof registry unavailable"))?;
+                map.get(request.id().unwrap_or_default())
+                    .filter(|h| &h.actor == actor)
+                    .cloned()
+                    .ok_or_else(|| {
+                        err(
+                            "external-proof-not-found",
+                            "proof is absent, expired, or owned by another actor",
+                        )
+                    })?
+            };
+            handle
+                .tx
+                .try_send(Message { request, reply })
+                .map_err(|_| {
+                    err(
+                        "external-proof-busy",
+                        "proof is busy or closing; inspect before retrying",
+                    )
+                })?;
+        }
+        receiver.await.map_err(|_| {
+            err(
+                "external-proof-closed",
+                "proof worker terminated; no success may be inferred",
+            )
+        })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn proof() -> Proof {
+        Proof::new(
+            "ecup-test".into(),
+            json!({"jobSha256":"a".repeat(64)}),
+            actor_record(&ActorBinding::local_process(Some("principal:test".into()))),
+            Instant::now(),
+            now(),
+            json!({"sha256":"b".repeat(64),"byteLength":33,"width":1,"height":1,"pngBase64":"private"}),
+        )
+    }
+    #[test]
+    fn external_commands_reject_duplicate_unknown_and_trailing_data() {
+        for raw in [
+            r#"{"op":"status","op":"abort","proof_id":"x"}"#,
+            r#"{"op":"status","proof_id":"x","actor":"owner"}"#,
+            r#"{"op":"status","proof_id":"x"} {}"#,
+        ] {
+            assert!(parse(raw).is_err());
+        }
+        assert!(parse(r#"{"op":"status","proof_id":"x"}"#).is_ok());
+    }
+    #[test]
+    fn external_actions_are_bounded_closed_and_clipboard_free() {
+        for raw in [
+            "[]",
+            r#"[{"type":"paste","text":"secret"}]"#,
+            r#"[{"type":"mouse_down","x":1,"y":1}]"#,
+            r#"[{"type":"wait","ms":5001}]"#,
+            r#"[{"type":"key","key":"x","shell":"bad"}]"#,
+            r#"[{"type":"type","text":"a","text":"b"}]"#,
+        ] {
+            assert!(actions(raw).is_err(), "{raw}");
+        }
+        assert!(
+            actions(r#"[{"type":"click","x":1,"y":2},{"type":"type","text":"public"}]"#).is_ok()
+        );
+        assert!(actions(
+            &json!((0..17)
+                .map(|_| json!({"type":"screenshot"}))
+                .collect::<Vec<_>>())
+            .to_string()
+        )
+        .is_err());
+        assert!(actions(&json!([{"type":"type","text":"x".repeat(4097)}]).to_string()).is_err());
+    }
+    #[test]
+    fn external_replayed_sequence_never_advances_state() {
+        let mut proof = proof();
+        proof.sequence = 4;
+        let request = Request::Actions {
+            proof_id: proof.id.clone(),
+            sequence: 3,
+            actions_json: r#"[{"type":"key","key":"a"}]"#.into(),
+        };
+        assert_eq!(
+            validate_step(&proof, &request).unwrap_err().code,
+            "external-proof-sequence"
+        );
+        assert_eq!(proof.action_count, 0);
+        assert_eq!(proof.sequence, 4);
+    }
+    #[test]
+    fn external_freeze_is_irreversible_and_observation_is_one_shot() {
+        let mut proof = proof();
+        for phase in [Phase::Frozen, Phase::Observed, Phase::Finished] {
+            proof.phase = phase;
+            assert!(validate_step(
+                &proof,
+                &Request::Actions {
+                    proof_id: proof.id.clone(),
+                    sequence: 0,
+                    actions_json: r#"[{"type":"screenshot"}]"#.into()
+                }
+            )
+            .is_err());
+            assert!(validate_step(
+                &proof,
+                &Request::Freeze {
+                    proof_id: proof.id.clone(),
+                    sequence: 0
+                }
+            )
+            .is_err());
+        }
+        proof.phase = Phase::Frozen;
+        let observe = Request::Observe {
+            proof_id: proof.id.clone(),
+            sequence: 0,
+            pre_observation_sha256: "c".repeat(64),
+        };
+        assert!(validate_step(&proof, &observe).is_ok());
+        proof.phase = Phase::Observed;
+        assert!(validate_step(&proof, &observe).is_err());
+    }
+    #[test]
+    fn external_claims_require_exact_issued_frame_and_unique_json() {
+        let mut proof = proof();
+        proof.phase = Phase::Observed;
+        for (hash, claims) in [
+            ("a".repeat(64), "{}"),
+            ("b".repeat(64), r#"{"ready":true,"ready":false}"#),
+            ("b".repeat(64), "[]"),
+        ] {
+            assert!(validate_step(
+                &proof,
+                &Request::Finish {
+                    proof_id: proof.id.clone(),
+                    sequence: 0,
+                    observation_sha256: hash,
+                    claims_json: claims.into()
+                }
+            )
+            .is_err());
+        }
+        assert!(validate_step(
+            &proof,
+            &Request::Finish {
+                proof_id: proof.id.clone(),
+                sequence: 0,
+                observation_sha256: "b".repeat(64),
+                claims_json: "{}".into()
+            }
+        )
+        .is_ok());
+    }
+    #[test]
+    fn external_total_action_budget_cannot_be_split_across_calls() {
+        let mut proof = proof();
+        proof.action_count = 64;
+        assert!(validate_step(
+            &proof,
+            &Request::Actions {
+                proof_id: proof.id.clone(),
+                sequence: 0,
+                actions_json: r#"[{"type":"wait","ms":1}]"#.into()
+            }
+        )
+        .is_err());
+    }
+    #[test]
+    fn external_redaction_has_no_typed_text_or_low_entropy_text_hash() {
+        let one = actions(r#"[{"type":"type","text":"1234"}]"#).unwrap();
+        let two = actions(r#"[{"type":"type","text":"other-value"}]"#).unwrap();
+        assert_eq!(
+            action_projection_sha256(&one).unwrap(),
+            action_projection_sha256(&two).unwrap()
+        );
+    }
+    #[test]
+    fn external_receipt_is_domain_separated_without_a_model_claim() {
+        let mut proof = proof();
+        proof.phase = Phase::Observed;
+        proof.frozen_at = Some(now());
+        proof.observed_at = Some(now());
+        let receipt = proof.make_receipt(r#"{"ready":true}"#).unwrap();
+        assert_eq!(receipt["execution"]["internalModelCalls"], 0);
+        assert_eq!(receipt["execution"]["claimsAuthority"], "external-caller");
+        assert!(receipt.get("provider").is_none());
+        assert!(receipt.get("model").is_none());
+        assert!(receipt["observation"].get("pngBase64").is_none());
+        let mut payload = receipt.clone();
+        let id = payload
+            .as_object_mut()
+            .unwrap()
+            .remove("receiptId")
+            .unwrap();
+        assert_eq!(
+            id,
+            format!(
+                "ecup-receipt:{}",
+                hash_value("intendant-external-cu-receipt-v1", &payload)
+            )
+        );
+        payload["claimsJson"] = json!("{}");
+        assert_ne!(
+            id,
+            format!(
+                "ecup-receipt:{}",
+                hash_value("intendant-external-cu-receipt-v1", &payload)
+            )
+        );
+    }
+    #[test]
+    fn external_actor_identity_is_not_a_caller_label() {
+        let first = ActorBinding::local_process(Some("principal:a".into()));
+        let second = ActorBinding::local_process(Some("principal:b".into()));
+        assert_ne!(first, second);
+        assert_ne!(actor_record(&first), actor_record(&second));
+        assert!(require_owner_surface(ToolCallerTrust::Scoped).is_err());
+    }
+    #[test]
+    fn external_close_requires_a_completed_claim_receipt() {
+        let mut proof = proof();
+        let close = Request::Close {
+            proof_id: proof.id.clone(),
+            sequence: 0,
+        };
+        assert!(validate_step(&proof, &close).is_err());
+        proof.phase = Phase::Finished;
+        assert!(validate_step(&proof, &close).is_ok());
+    }
+    #[test]
+    fn external_tool_is_not_advertised_to_scoped_profiles() {
+        for profile in [
+            Some("core"),
+            Some("codex-core"),
+            Some("cli"),
+            Some("minimal"),
+            Some("screen"),
+            Some("display"),
+            Some("managed"),
+            Some("facade"),
+        ] {
+            assert!(!tool_allowed_for_profile(
+                "external_cu_proof",
+                false,
+                profile
+            ));
+        }
+        let mut manual = Vec::new();
+        append_manual_http_tool_definitions(&mut manual, false, None);
+        let tool = manual
+            .iter()
+            .find(|tool| tool["name"] == "external_cu_proof")
+            .expect("external proof manual definition");
+        assert_eq!(
+            tool["description"].as_str(),
+            IntendantServer::external_cu_proof_tool_attr()
+                .description
+                .as_deref()
+        );
+    }
+}

--- a/src/bin/caller/mcp/tools_bounded_cu/external.rs
+++ b/src/bin/caller/mcp/tools_bounded_cu/external.rs
@@ -285,7 +285,7 @@ impl Proof {
     }
     fn snapshot(&self) -> Value {
         json!({"ok":true,"profile":PROFILE,"proofId":self.id,"sequence":self.sequence,"binding":self.binding,"actor":self.actor,
-            "phase":self.phase.name(),"frame":self.frame,"receipt":self.receipt})
+            "phase":self.phase.name(),"startedAt":self.started_at,"frozenAt":self.frozen_at,"observedAt":self.observed_at,"actionCount":self.action_count,"inputEventCount":self.input_count,"frame":self.frame,"receipt":self.receipt})
     }
     fn check_sequence(&self, request: &Request) -> Result<(), BoundedCuTaskError> {
         if request.sequence().is_some_and(|seq| seq != self.sequence) {

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -162,6 +162,8 @@ impl IntendantServer {
                 request_id: Some(request_id.clone()),
                 width: params.width,
                 height: params.height,
+                minimum_display_id: params.minimum_display_id,
+                maximum_display_id: params.maximum_display_id,
             }));
         match waiter.wait(std::time::Duration::from_secs(20)).await {
             Ok(crate::event::VirtualDisplayCreateOutcome::Created {
@@ -1848,6 +1850,8 @@ mod tests {
                     request_id: Some(request_id),
                     width,
                     height,
+                    minimum_display_id: None,
+                    maximum_display_id: None,
                 }))) => return (request_id, width, height),
                 Ok(Ok(_)) => continue,
                 other => panic!("expected correlated create command, got {other:?}"),
@@ -1867,6 +1871,8 @@ mod tests {
                 .create_virtual_display(Parameters(CreateVirtualDisplayParams {
                     width: Some(800),
                     height: Some(600),
+                    minimum_display_id: None,
+                    maximum_display_id: None,
                 }))
                 .await
         });
@@ -1876,6 +1882,8 @@ mod tests {
                 .create_virtual_display(Parameters(CreateVirtualDisplayParams {
                     width: Some(1000),
                     height: Some(700),
+                    minimum_display_id: None,
+                    maximum_display_id: None,
                 }))
                 .await
         });

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -182,6 +182,34 @@ pub(crate) fn virtual_display_dimensions(
     Ok((width & !1, height & !1))
 }
 
+/// Optional creation policy. Omitted pool bounds preserve the generic allocator.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct VirtualDisplayCreateOptions {
+    pub(crate) width: Option<u32>,
+    pub(crate) height: Option<u32>,
+    pub(crate) minimum_display_id: Option<u32>,
+    pub(crate) maximum_display_id: Option<u32>,
+}
+
+fn constrain_display_pool(
+    exclude: &mut Vec<u32>,
+    minimum: Option<u32>,
+    maximum: Option<u32>,
+) -> Result<(), String> {
+    match (minimum, maximum) {
+        (None, None) => Ok(()),
+        (Some(minimum), Some(maximum)) if minimum >= vision::PREFERRED_DISPLAY && maximum < vision::VIRTUAL_DISPLAY_END && minimum <= maximum => {
+            // Reuse the allocator's ordinary exclusion semantics. No display is
+            // created, reclaimed or touched merely to reserve a lower number.
+            exclude.extend((vision::PREFERRED_DISPLAY..vision::VIRTUAL_DISPLAY_END).filter(|id| *id < minimum || *id > maximum));
+            exclude.sort_unstable();
+            exclude.dedup();
+            Ok(())
+        }
+        _ => Err("virtual display pool requires both inclusive bounds with 99 <= minimum <= maximum <= 199".to_owned()),
+    }
+}
+
 /// Handle `ControlMsg::CreateVirtualDisplay`: launch an Xvfb at a free
 /// display number and register its capture session so every dashboard gets
 /// a streaming tile. Pre-activation failures report through
@@ -192,8 +220,7 @@ pub(crate) async fn create_virtual_display(
     session_registry: &display::SharedSessionRegistry,
     frame_registry: Option<Arc<tokio::sync::RwLock<frames::FrameRegistry>>>,
     guards: &mut VirtualDisplayGuards,
-    width: Option<u32>,
-    height: Option<u32>,
+    options: VirtualDisplayCreateOptions,
     request_id: Option<String>,
 ) {
     // The lossless intent lane can outlive its synchronous caller. Refuse an
@@ -229,7 +256,15 @@ pub(crate) async fn create_virtual_display(
         }
     }
 
-    let (width, height) = match virtual_display_dimensions(width, height) {
+    if let Err(reason) = constrain_display_pool(
+        &mut exclude,
+        options.minimum_display_id,
+        options.maximum_display_id,
+    ) {
+        report_virtual_display_create_failed(bus, request_id.as_deref(), reason);
+        return;
+    }
+    let (width, height) = match virtual_display_dimensions(options.width, options.height) {
         Ok(dims) => dims,
         Err(reason) => {
             report_virtual_display_create_failed(bus, request_id.as_deref(), reason);
@@ -757,6 +792,58 @@ mod tests {
         sender: Mutex<Option<mpsc::Sender<Frame>>>,
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn requested_pool_allocator_uses_only_eligible_absent_slots() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join(".X120-lock"), b"foreign-test-marker").unwrap();
+        let mut excluded = vec![];
+        constrain_display_pool(&mut excluded, Some(120), Some(121)).unwrap();
+        let config = vision::virtual_display_config_in(temp.path(), 800, 600, &excluded).unwrap();
+        assert_eq!(virtual_target_id(&config), Some(121));
+        excluded.push(121);
+        assert!(vision::virtual_display_config_in(temp.path(), 800, 600, &excluded).is_none());
+        assert_eq!(
+            std::fs::read(temp.path().join(".X120-lock")).unwrap(),
+            b"foreign-test-marker"
+        );
+    }
+
+    #[test]
+    fn requested_pool_preserves_default_and_existing_exclusions() {
+        let mut excluded = vec![121, 155];
+        constrain_display_pool(&mut excluded, None, None).unwrap();
+        assert_eq!(excluded, vec![121, 155]);
+        constrain_display_pool(&mut excluded, Some(120), Some(159)).unwrap();
+        let remaining: Vec<_> = (vision::PREFERRED_DISPLAY..vision::VIRTUAL_DISPLAY_END)
+            .filter(|id| !excluded.contains(id))
+            .collect();
+        assert_eq!(remaining.len(), 38);
+        assert!(remaining.iter().all(|id| (120..=159).contains(id)));
+        assert!(!remaining.contains(&121));
+    }
+    #[test]
+    fn requested_pool_rejects_partial_inverted_and_outside_bounds() {
+        for pair in [
+            (None, Some(159)),
+            (Some(120), None),
+            (Some(0), Some(159)),
+            (Some(120), Some(200)),
+            (Some(159), Some(120)),
+        ] {
+            let mut excluded = vec![140];
+            assert!(constrain_display_pool(&mut excluded, pair.0, pair.1).is_err());
+            assert_eq!(excluded, vec![140]);
+        }
+    }
+    #[test]
+    fn exhausted_requested_pool_cannot_fall_back_outside_it() {
+        let mut excluded: Vec<_> = (120..=159).collect();
+        constrain_display_pool(&mut excluded, Some(120), Some(159)).unwrap();
+        assert!((vision::PREFERRED_DISPLAY..vision::VIRTUAL_DISPLAY_END)
+            .all(|id| excluded.contains(&id)));
+    }
+
     #[async_trait::async_trait]
     impl DisplayBackend for TestCaptureBackend {
         async fn start_capture(&self, _fps: u32) -> Result<mpsc::Receiver<Frame>, CallerError> {
@@ -1057,8 +1144,11 @@ mod tests {
             &registry,
             None,
             &mut guards,
-            Some(1280),
-            Some(720),
+            VirtualDisplayCreateOptions {
+                width: Some(1280),
+                height: Some(720),
+                ..Default::default()
+            },
             Some("vdc-no-longer-pending".to_string()),
         )
         .await;


### PR DESCRIPTION
Adds bounded virtual-display allocation ranges, private profile creation and tests. Real provider-free CU acceptance allocates in Scout pool 120-159 and retains exact generation-bound teardown. Submission authority remains disabled.