### PR TITLE
Fix pinned-wallet first-run target selection and native viewport convergence

### DIFF
--- a/scripts/test-rabby-proof-viewport.py
+++ b/scripts/test-rabby-proof-viewport.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Cold-start pinned Rabby on three fresh proof displays. No keys or transactions."""
+import argparse, fcntl, hashlib, json, os, pathlib, shutil, socket, subprocess, time
+
+ARCHIVE_SHA = 'daf7819d7371a67ef447c788e899b1df628f95e380a460c6e5dd3b86bbe09e4f'
+ARCHIVE_BYTES = 16216742
+METRICS_JS = r'''
+const [port,id]=process.argv.slice(1);
+const controller=new AbortController(),timer=setTimeout(()=>controller.abort(),3000);
+const targets=await(await fetch(`http://127.0.0.1:${port}/json/list`,{signal:controller.signal})).json();clearTimeout(timer);
+const page=targets.find(p=>p.id===id && p.type==='page');if(!page)throw Error('bound page missing');
+if(page.url.startsWith('chrome-extension:'))throw Error('onboarding selected instead of application');
+const endpoint=new URL(page.webSocketDebuggerUrl);
+if(endpoint.hostname!=='127.0.0.1'||endpoint.port!==port||endpoint.pathname!==`/devtools/page/${id}`)throw Error('foreign CDP endpoint');
+const ws=new WebSocket(endpoint);const result=await new Promise((resolve,reject)=>{
+const timeout=setTimeout(()=>reject(Error('CDP deadline')),3000);
+ws.onerror=()=>reject(Error('CDP failed'));ws.onopen=()=>ws.send(JSON.stringify({id:1,method:'Page.getLayoutMetrics'}));
+ws.onmessage=event=>{const value=JSON.parse(event.data);if(value.id===1){clearTimeout(timeout);if(value.error)reject(Error('metrics refused'));else resolve(value.result);}};
+});ws.close();console.log(JSON.stringify(result));
+'''
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__)
+    for name in ('bin','archive','cache-root','capture-state-root','node','evidence'):
+        parser.add_argument('--'+name,required=True,type=pathlib.Path)
+    parser.add_argument('--target',default='https://example.org/')
+    args=parser.parse_args()
+    if not args.target.startswith('https://'):raise RuntimeError('HTTPS test target required')
+    archive=args.archive.resolve(strict=True)
+    if archive.stat().st_size!=ARCHIVE_BYTES or hashlib.sha256(archive.read_bytes()).hexdigest()!=ARCHIVE_SHA:
+        raise RuntimeError('pinned Rabby archive does not match')
+    if subprocess.run(['pgrep','-x','Runner.Worker'],stdout=subprocess.DEVNULL).returncode!=1:
+        raise RuntimeError('CI has priority')
+    os.umask(0o077)
+    # Serialize with production capture. Do not remove a lock or cleanup quarantine.
+    state=args.capture_state_root.resolve(strict=True)
+    lock=(state/'capture.lock').open('r+')
+    fcntl.flock(lock,fcntl.LOCK_EX|fcntl.LOCK_NB)
+    if (state/'cleanup-pending').exists() and any((state/'cleanup-pending').iterdir()):
+        raise RuntimeError('capture cleanup is pending')
+    out=args.evidence.absolute();out.mkdir(mode=0o700)
+    home=out/'home';home.mkdir(mode=0o700)
+    binary=str(args.bin.resolve(strict=True));node=str(args.node.resolve(strict=True))
+    env={'PATH':'/usr/local/bin:/usr/bin:/bin','HOME':str(home),'INTENDANT_HOME':str(home/'.intendant'),
+         'LANG':'C.UTF-8','XDG_CACHE_HOME':str(args.cache_root.resolve(strict=True))}
+    with socket.socket() as sock:sock.bind(('127.0.0.1',0));port=sock.getsockname()[1]
+    log=(out/'daemon.log').open('wb')
+    daemon=subprocess.Popen([binary,'--web',str(port),'--bind','127.0.0.1','--no-tls','--no-presence'],env=env,cwd=out,stdin=subprocess.DEVNULL,stdout=log,stderr=subprocess.STDOUT)
+    def ctl(*argv):
+        p=subprocess.run([binary,'ctl','--port',str(port),'--json',*argv],env=env,cwd=out,stdin=subprocess.DEVNULL,capture_output=True,text=True,timeout=30)
+        if p.returncode:raise RuntimeError('test control failed; private daemon log retained')
+        value=json.loads(p.stdout)
+        if isinstance(value,dict) and value.get('ok') is False:raise RuntimeError(str(value.get('error','tool refused')))
+        return value
+    display=browser=None;results=[];clean=True
+    try:
+        for _ in range(60):
+            try:ctl('whoami');break
+            except Exception:
+                if daemon.poll() is not None:raise RuntimeError('test daemon exited')
+                time.sleep(.2)
+        baseline=ctl('display','list')
+        for n in range(3):
+            parent=out/f'attempt-{n}';parent.mkdir(mode=0o700)
+            display=ctl('display','create','--width','1920','--height','1080','--min-display-id','120','--max-display-id','159')
+            browser=ctl('browser','create',args.target,'--provider','cdp','--display-target',display['display_target'],
+                '--session',f'viewport-rabby-{n}','--profile-dir',str(parent/'browser-profile'),'--viewport','1024x768',
+                '--extension-archive',str(archive),'--extension-sha256',ARCHIVE_SHA,'--extension-bytes',str(ARCHIVE_BYTES),
+                '--extension-manifest-version','3','--extension-version','0.94.6')
+            p=subprocess.run([node,'--input-type=module','-e',METRICS_JS,str(browser['debugging_port']),browser['active_target_id']],stdin=subprocess.DEVNULL,capture_output=True,text=True,timeout=10)
+            if p.returncode:raise RuntimeError('independent CDP metrics check failed')
+            metrics=json.loads(p.stdout);css=metrics['cssLayoutViewport']
+            if (css['clientWidth'],css['clientHeight'])!=(1024,768):raise RuntimeError('native viewport mismatch')
+            (parent/'browser.json').write_text(json.dumps(browser));(parent/'metrics.json').write_text(json.dumps(metrics))
+            results.append({'attempt':n,'width':css['clientWidth'],'height':css['clientHeight'],'extensionRuntimeId':browser['extension']['runtime_id']})
+            if ctl('browser','close',browser['id'],'--reason','viewport-regression')['status']!='closed':raise RuntimeError('browser close failed')
+            browser=None
+            if not ctl('display','destroy',str(display['display_id']),display['capture_generation'],'--note','viewport-regression')['ok']:raise RuntimeError('exact teardown failed')
+            display=None
+            if (parent/'browser-profile').exists():shutil.rmtree(parent/'browser-profile')
+        if ctl('display','list')!=baseline:raise RuntimeError('display leaked')
+        result={'passed':True,'attempts':results,'privateKeysGenerated':False,'transactionsRequested':False,
+                'binarySha256':hashlib.sha256(pathlib.Path(binary).read_bytes()).hexdigest()}
+        (out/'RESULT.json').write_text(json.dumps(result));print(json.dumps(result),flush=True)
+    finally:
+        if browser:
+            try:ctl('browser','close',browser['id'],'--reason','viewport-failed-cleanup')
+            except Exception:clean=False
+        if display:
+            try:ctl('display','destroy',str(display['display_id']),display['capture_generation'],'--note','viewport-failed-cleanup')
+            except Exception:clean=False
+        daemon.terminate()
+        try:daemon.wait(timeout=15)
+        except subprocess.TimeoutExpired:daemon.kill();daemon.wait(timeout=5)
+        log.close()
+        (out/'CLEANUP.json').write_text(json.dumps({'exactResourceCleanupConfirmed':clean,'testDaemonStopped':True}))
+        lock.close()
+
+if __name__=='__main__':main()

--- a/scripts/test-rabby-proof-viewport.py
+++ b/scripts/test-rabby-proof-viewport.py
@@ -78,16 +78,21 @@ def main():
             if not ctl('display','destroy',str(display['display_id']),display['capture_generation'],'--note','viewport-regression')['ok']:raise RuntimeError('exact teardown failed')
             display=None
             if (parent/'browser-profile').exists():shutil.rmtree(parent/'browser-profile')
-        if ctl('display','list')!=baseline:raise RuntimeError('display leaked')
+        if ctl('display','list')!=baseline:
+            clean=False
+            raise RuntimeError('display leaked')
         result={'passed':True,'attempts':results,'privateKeysGenerated':False,'transactionsRequested':False,
                 'binarySha256':hashlib.sha256(pathlib.Path(binary).read_bytes()).hexdigest()}
         (out/'RESULT.json').write_text(json.dumps(result));print(json.dumps(result),flush=True)
+    except BaseException:
+        clean=False
+        raise
     finally:
         if browser:
-            try:ctl('browser','close',browser['id'],'--reason','viewport-failed-cleanup')
+            try:clean = (ctl('browser','close',browser['id'],'--reason','viewport-failed-cleanup').get('status')=='closed') and clean
             except Exception:clean=False
         if display:
-            try:ctl('display','destroy',str(display['display_id']),display['capture_generation'],'--note','viewport-failed-cleanup')
+            try:clean = (ctl('display','destroy',str(display['display_id']),display['capture_generation'],'--note','viewport-failed-cleanup').get('ok') is True) and clean
             except Exception:clean=False
         daemon.terminate()
         try:daemon.wait(timeout=15)

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -2500,6 +2500,39 @@ fn validated_page_target(value: &serde_json::Value, port: u16) -> Option<(String
     })
 }
 
+// An extension's onboarding page may be first in /json/list. Never bind the
+// application's lease or geometry to that internal page. A fresh launch has
+// exactly one non-extension page; ambiguous application surfaces fail closed.
+fn select_launch_page_target(
+    value: &serde_json::Value,
+    port: u16,
+    extension_required: bool,
+) -> Option<(String, String)> {
+    if !extension_required {
+        return validated_page_target(value, port);
+    }
+    let pages: Vec<_> = value
+        .as_array()?
+        .iter()
+        .filter(|target| {
+            target.get("type").and_then(serde_json::Value::as_str) == Some("page")
+                && target
+                    .get("url")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|url| {
+                        url.starts_with("https://")
+                            || url.starts_with("http://")
+                            || url == "about:blank"
+                    })
+        })
+        .cloned()
+        .collect();
+    if pages.len() != 1 {
+        return None;
+    }
+    validated_page_target(&serde_json::Value::Array(pages), port)
+}
+
 async fn wait_for_cdp_target(
     child: &mut Child,
     profile_dir: &Path,
@@ -2570,7 +2603,11 @@ async fn wait_for_cdp_target_until(
                         {
                             Ok(targets) => {
                                 let extension_runtime_id = active_extension_runtime_id(&targets);
-                                match validated_page_target(&targets, endpoint.port) {
+                                match select_launch_page_target(
+                                    &targets,
+                                    endpoint.port,
+                                    extension_required,
+                                ) {
                                     Some((ws, id))
                                         if !extension_required
                                             || extension_runtime_id.is_some() =>
@@ -4282,5 +4319,30 @@ mod tests {
         let found = find_executable_under(temp.path(), &["Google Chrome for Testing"], 6)
             .expect("managed browser executable should be found");
         assert_eq!(found, executable);
+    }
+    #[test]
+    fn extension_launch_never_selects_onboarding_or_ambiguous_apps() {
+        let page = |id: &str, url: &str| {
+            serde_json::json!({"type":"page","id":id,"url":url,
+            "webSocketDebuggerUrl":format!("ws://127.0.0.1:9222/devtools/page/{id}")})
+        };
+        let onboarding = page(
+            "onboarding",
+            "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/index.html",
+        );
+        let app = page("application", "https://example.org/");
+        let pages = serde_json::json!([onboarding.clone(), app.clone()]);
+        assert_eq!(
+            select_launch_page_target(&pages, 9222, true).unwrap().1,
+            "application"
+        );
+        assert!(select_launch_page_target(&serde_json::json!([onboarding]), 9222, true).is_none());
+        assert!(select_launch_page_target(
+            &serde_json::json!([app.clone(), page("second", "https://other.example/")]),
+            9222,
+            true
+        )
+        .is_none());
+        assert!(select_launch_page_target(&serde_json::json!([app]), 9999, true).is_none());
     }
 }

--- a/src/bin/caller/browser_workspace/proof_viewport.rs
+++ b/src/bin/caller/browser_workspace/proof_viewport.rs
@@ -134,6 +134,11 @@ async fn configure_inner(
         next: 0,
         total: 0,
     };
+    // A pinned extension can open its first-run tab while CDP is becoming
+    // ready. Background tabs retain stale layout metrics when the OS window
+    // resizes. Activate only this already-authenticated page during pre-publication
+    // geometry setup; do not emulate a viewport or mutate page content.
+    client.call("Page.bringToFront", json!({})).await?;
     let window = client
         .call("Browser.getWindowForTarget", json!({"targetId":target}))
         .await?;
@@ -149,9 +154,12 @@ async fn configure_inner(
         .await?;
     let mut width = i64::from(want.width);
     let mut height = i64::from(want.height) + 120;
-    for _ in 0..8 {
+    let mut samples = Vec::new();
+    for _ in 0..20 {
         if !(256..=4096).contains(&width) || !(144..=2304).contains(&height) {
-            return Err(error("proof viewport outer window exceeded bounds"));
+            return Err(error(format!(
+                "proof viewport outer window exceeded bounds: {samples:?}"
+            )));
         }
         client
             .call(
@@ -159,7 +167,8 @@ async fn configure_inner(
                 json!({"windowId":id,"bounds":{"left":0,"top":0,"width":width,"height":height}}),
             )
             .await?;
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        client.call("Page.bringToFront", json!({})).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let metrics = client.call("Page.getLayoutMetrics", json!({})).await?;
         let css = &metrics["cssLayoutViewport"];
         let device = &metrics["layoutViewport"];
@@ -169,6 +178,29 @@ async fn configure_inner(
         let actual_height = css["clientHeight"]
             .as_i64()
             .ok_or_else(|| error("proof viewport CSS height missing"))?;
+        let bounds = client
+            .call("Browser.getWindowBounds", json!({"windowId":id}))
+            .await?;
+        let outer_width = bounds["bounds"]["width"]
+            .as_i64()
+            .ok_or_else(|| error("proof outer width missing"))?;
+        let outer_height = bounds["bounds"]["height"]
+            .as_i64()
+            .ok_or_else(|| error("proof outer height missing"))?;
+        if !(256..=4096).contains(&outer_width) || !(144..=2304).contains(&outer_height) {
+            return Err(error("proof window reported invalid outer bounds"));
+        }
+        samples.push((
+            width,
+            height,
+            actual_width,
+            actual_height,
+            outer_width,
+            outer_height,
+        ));
+        if actual_width <= 0 || actual_height <= 0 {
+            continue;
+        }
         if actual_width == i64::from(want.width) && actual_height == i64::from(want.height) {
             if device["clientWidth"] != css["clientWidth"]
                 || device["clientHeight"] != css["clientHeight"]
@@ -177,8 +209,11 @@ async fn configure_inner(
             }
             return Ok(());
         }
-        width += i64::from(want.width) - actual_width;
-        height += i64::from(want.height) - actual_height;
+        // Resize acknowledgement and tab layout are asynchronous. Use the
+        // observed outer geometry, not the prior requested bounds: accumulating
+        // deltas from a background tab can otherwise grow the window endlessly.
+        width = outer_width + i64::from(want.width) - actual_width;
+        height = outer_height + i64::from(want.height) - actual_height;
     }
     Err(error(
         "browser did not reach the exact requested proof viewport",
@@ -210,5 +245,74 @@ mod tests {
                 height: 768
             })
         );
+    }
+    #[tokio::test]
+    async fn activates_only_the_bound_page_before_measuring_native_geometry() {
+        use tokio::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let mut activations = 0;
+            let mut methods = Vec::new();
+            while let Some(Ok(Message::Text(text))) = ws.next().await {
+                let v: Value = serde_json::from_str(&text).unwrap();
+                let method = v["method"].as_str().unwrap();
+                methods.push(method.to_owned());
+                let result = match method {
+                    "Page.bringToFront" => {
+                        activations += 1;
+                        json!({})
+                    }
+                    "Browser.getWindowForTarget" => {
+                        assert!(activations > 0);
+                        assert_eq!(v["params"]["targetId"], "owned-target");
+                        json!({"windowId":7})
+                    }
+                    "Browser.getWindowBounds" => {
+                        assert_eq!(v["params"]["windowId"], 7);
+                        json!({"bounds":{"width":1024,"height":888}})
+                    }
+                    "Browser.setWindowBounds" => {
+                        assert_eq!(v["params"]["windowId"], 7);
+                        json!({})
+                    }
+                    "Page.getLayoutMetrics" => {
+                        assert!(activations >= 2);
+                        json!({"layoutViewport":{"clientWidth":1024,"clientHeight":768},
+                            "cssLayoutViewport":{"clientWidth":1024,"clientHeight":768}})
+                    }
+                    other => panic!("unexpected geometry operation: {other}"),
+                };
+                ws.send(Message::Text(
+                    json!({"id":v["id"],"result":result}).to_string().into(),
+                ))
+                .await
+                .unwrap();
+                if method == "Browser.getWindowBounds" {
+                    break;
+                }
+            }
+            assert_eq!(
+                methods.first().map(String::as_str),
+                Some("Page.bringToFront")
+            );
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            configure_inner(
+                &format!("ws://127.0.0.1:{port}/devtools/page/owned-target"),
+                "owned-target",
+                Viewport {
+                    width: 1024,
+                    height: 768,
+                },
+            )
+            .await
+            .unwrap();
+            server.await.unwrap();
+        })
+        .await
+        .unwrap();
     }
 }


### PR DESCRIPTION
Keeps fresh pinned-wallet onboarding out of the application lease; only one public/blank application page can be selected. Activates the exact bound application for native geometry, computes corrections from observed outer bounds, and keeps the hard deadline. Adds strict selection and CDP ordering tests plus a parameterized three-cold-launch Rabby acceptance harness. Real Linux runs reached CSS 1024x768 on all three fresh extension displays. No page-content mutation, emulated viewport, signing key or transaction. No production rollout in this PR creation step.