### PR TITLE
Add owner-controlled managed-browser testing notice policy

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -120,6 +120,7 @@ precedence is **explicit config > env var > auto-detect**.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE` | unset (off) | Owner startup opt-in: `1` adds `--test-type=gpu` only to Intendant-managed Chrome for Testing; `0` disables it; other values reject startup. See test-mode effects below. |
 | `INTENDANT_BROWSER_WORKSPACE_EXECUTABLE` | managed browser cache | Explicit Chromium/Chrome-for-Testing executable for CDP browser workspaces |
 | `INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER` | `false` on macOS, `true` elsewhere | On macOS, explicitly permit CDP workspaces to launch system Chrome/Chromium apps such as `/Applications/Google Chrome.app` |
 
@@ -136,6 +137,44 @@ Run `intendant setup browsers` to download Chrome for Testing into Intendant's
 managed cache. The helper accepts `--check`, `--force`,
 `--channel stable|beta|dev|canary`, `--json`, and `--print-path`; use
 `--check` to verify the cache without network access.
+
+The testing-notice option is captured from the owner's process environment before
+project `.env` files load. Daemon successor launches explicitly carry that sealed
+boolean as `0` or `1`, including when originally unset, overriding inherited
+project values (even invalid ones) across repeated handovers. Changing it requires
+a fresh owner launch with the new environment, not a successor handover. It adds exactly
+`--test-type=gpu` to browsers resolved from the cache populated by
+`intendant setup browsers` (`intendant-managed-cache`), including approved
+extension workspaces. Other managed caches, explicit executable overrides, and
+system browsers receive no added flag. Discovery order is unchanged; the source label records discovery provenance,
+not cryptographic verification of the executable. The launch URL is validated
+before allocating workspace resources: omitted/empty means `about:blank`, while
+switch-shaped input, control characters and invalid absolute URLs are rejected.
+Valid custom schemes and query strings are preserved without a scheme allowlist.
+A `--` terminator separates fixed Chromium switches from the single positional
+navigation argument. There is no arbitrary Chromium-argument API. This boundary
+prevents launch navigation from supplying switches; it does not constrain what
+an owner-selected executable does or certify a URL's content. Recorded launch
+arguments include the actual flag and terminator passed to the child.
+
+This selects **real Chromium test mode**, not a notice-only cosmetic switch.
+In Chromium 152.0.7977.82, [startup infobar code](https://github.com/chromium/chromium/blob/152.0.7977.82/chrome/browser/ui/startup/infobar_utils.cc)
+checks the exact `gpu` value to omit the Chrome for Testing notice. Any test-type
+also skips later startup prompts, including bad-command-line-flag, missing API
+key, unsupported OS, and OSCrypt availability warnings; automation and crash
+handling occur before that early return. This does not change the
+`CommandLineFlagSecurityWarningsEnabled` policy. Additional verified effects:
+[macOS Finder reveal](https://github.com/chromium/chromium/blob/152.0.7977.82/chrome/browser/platform_util_mac.mm)
+is skipped;
+[extension test APIs](https://github.com/chromium/chromium/blob/152.0.7977.82/extensions/renderer/script_context.cc)
+pass their test-mode availability gate; and
+[extension content-capability matching](https://github.com/chromium/chromium/blob/152.0.7977.82/extensions/common/manifest_handlers/content_capabilities_handler.cc)
+accepts HTTP as well as HTTPS patterns. Chromium
+[propagates test-type to renderers](https://github.com/chromium/chromium/blob/152.0.7977.82/content/browser/renderer_host/render_process_host_impl.cc).
+These are verified effects, not an exhaustive or cross-version guarantee. This
+option adds no Safe Browsing, certificate-validation, or wallet-warning bypass;
+it leaves existing launcher flags and extension approval requirements unchanged.
+Use it only when these test-mode effects are acceptable.
 
 Browser extensions default to **deny all**. Approval is not an environment or
 `intendant.toml` setting. Supply both `--browser-extension-policy PATH` and

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -120,7 +120,7 @@ precedence is **explicit config > env var > auto-detect**.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE` | unset (off) | Owner startup opt-in: `1` adds `--test-type=gpu` only to Intendant-managed Chrome for Testing; `0` disables it; other values reject startup. See test-mode effects below. |
+| `INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE` | unset (off) | Owner startup opt-in: `1` adds `--test-type=gpu` only to Intendant-managed Chrome for Testing; `0` disables it; other values reject startup. `service install` captures the owner environment before dotenv and persists canonical `0` (including unset) or `1` on all service backends. `service run --env` overrides inheritance with a valid explicit value; invalid values reject before service side effects. See test-mode effects below. |
 | `INTENDANT_BROWSER_WORKSPACE_EXECUTABLE` | managed browser cache | Explicit Chromium/Chrome-for-Testing executable for CDP browser workspaces |
 | `INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER` | `false` on macOS, `true` elsewhere | On macOS, explicitly permit CDP workspaces to launch system Chrome/Chromium apps such as `/Applications/Google Chrome.app` |
 

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -1,6 +1,12 @@
 mod extension_policy;
 mod viewport;
 
+pub(crate) mod launch_policy;
+
+pub(crate) fn initialize_testing_notice_policy() -> Result<(), BrowserWorkspaceError> {
+    launch_policy::initialize().map_err(|error| BrowserWorkspaceError::Launch(error.into()))
+}
+
 pub(crate) fn initialize_extension_policy(
     path: Option<&str>,
     sha256: Option<&str>,
@@ -795,6 +801,10 @@ pub async fn create_workspace(
     request: CreateBrowserWorkspaceRequest,
     bus: &EventBus,
 ) -> Result<BrowserWorkspace, BrowserWorkspaceError> {
+    // Validate navigation before display leases, registry reservations or filesystem effects.
+    let launch_url = launch_policy::navigation(request.url.as_deref())
+        .map_err(|error| BrowserWorkspaceError::Launch(error.into()))?
+        .map(str::to_owned);
     let viewport = viewport::parse(
         request.viewport.as_deref(),
         request.display_target.is_some(),
@@ -892,12 +902,7 @@ pub async fn create_workspace(
             .filter(|s| !s.is_empty())
             .unwrap_or("Browser workspace")
             .to_string(),
-        url: request
-            .url
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string),
+        url: launch_url,
         provider,
         requested_provider,
         placement,
@@ -1979,6 +1984,8 @@ async fn launch_cdp_browser(
     profile_dir: &Path,
     viewport: Option<viewport::Viewport>,
 ) -> Result<(Child, CdpLaunch), BrowserWorkspaceError> {
+    let navigation = launch_policy::navigation(workspace.url.as_deref())
+        .map_err(|error| BrowserWorkspaceError::Launch(error.into()))?;
     let extension_required = workspace.extension.is_some();
     let executable = resolve_chromium_executable(
         matches!(workspace.provider, BrowserWorkspaceProvider::SystemCdp),
@@ -2002,6 +2009,11 @@ async fn launch_cdp_browser(
     // If the async create request is cancelled while CDP readiness is being
     // awaited, dropping its future must also terminate the spawned browser.
     command.kill_on_drop(true);
+    launch_policy::apply_testing_notice_policy(
+        command.as_std_mut(),
+        &executable.source,
+        launch_policy::current(),
+    );
     if viewport.is_some() {
         command.arg("--force-device-scale-factor=1");
     }
@@ -2050,11 +2062,8 @@ async fn launch_cdp_browser(
         .arg("--password-store=basic");
     #[cfg(target_os = "macos")]
     command.arg("--use-mock-keychain");
-    if let Some(url) = workspace.url.as_ref() {
-        command.arg(url);
-    } else {
-        command.arg("about:blank");
-    }
+    launch_policy::append_navigation(command.as_std_mut(), navigation)
+        .map_err(|error| BrowserWorkspaceError::Launch(error.into()))?;
     let launch_arguments = recorded_browser_launch_arguments(&command)?;
     let mut child = command.spawn().map_err(|e| {
         BrowserWorkspaceError::Launch(format!(
@@ -2720,11 +2729,8 @@ fn resolve_chromium_executable(
     }
 
     if !allow_system_for_request {
-        if let Some(path) = find_managed_chromium_executable() {
-            return Ok(ChromiumExecutable {
-                path,
-                source: "managed-cache".to_string(),
-            });
+        if let Some(executable) = find_managed_chromium_with_source() {
+            return Ok(executable);
         }
     }
 
@@ -3004,9 +3010,21 @@ fn cft_platform() -> Result<&'static str, String> {
 }
 
 fn find_managed_chromium_executable() -> Option<PathBuf> {
+    find_managed_chromium_with_source().map(|executable| executable.path)
+}
+
+fn find_managed_chromium_with_source() -> Option<ChromiumExecutable> {
     for root in managed_browser_roots() {
         if let Some(path) = find_executable_under(&root, managed_browser_executable_names(), 8) {
-            return Some(path);
+            return Some(ChromiumExecutable {
+                path,
+                source: if root == managed_browser_install_root() {
+                    "intendant-managed-cache"
+                } else {
+                    "managed-cache"
+                }
+                .to_string(),
+            });
         }
     }
     None

--- a/src/bin/caller/browser_workspace/launch_policy.rs
+++ b/src/bin/caller/browser_workspace/launch_policy.rs
@@ -1,0 +1,212 @@
+//! Native launch boundaries: seal owner authority before dotenv, carry it on
+//! daemon succession, and keep navigation out of Chromium's switch parser.
+//! Source labels are resolver provenance, not executable attestation.
+use std::ffi::OsStr;
+use std::process::Command;
+use std::sync::OnceLock;
+
+const HIDE_TESTING_NOTICE_ENV: &str = "INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE";
+static HIDE_TESTING_NOTICE: OnceLock<bool> = OnceLock::new();
+
+pub(crate) fn initialize() -> Result<(), &'static str> {
+    let enabled = parse(std::env::var_os(HIDE_TESTING_NOTICE_ENV).as_deref())?;
+    HIDE_TESTING_NOTICE
+        .set(enabled)
+        .map_err(|_| "browser testing notice policy already initialized")
+}
+
+fn parse(raw: Option<&OsStr>) -> Result<bool, &'static str> {
+    match raw {
+        None => Ok(false),
+        Some(value) if value == "0" => Ok(false),
+        Some(value) if value == "1" => Ok(true),
+        _ => Err("INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE must be unset, 0, or 1"),
+    }
+}
+
+pub(crate) fn current() -> bool {
+    HIDE_TESTING_NOTICE.get().copied().unwrap_or(false)
+}
+
+pub(crate) fn preserve_for_successor(command: &mut Command) {
+    // Always override inheritance, including the originally-unset false case.
+    command.env(HIDE_TESTING_NOTICE_ENV, if current() { "1" } else { "0" });
+}
+
+pub(crate) fn apply_testing_notice_policy(command: &mut Command, source: &str, enabled: bool) {
+    if enabled && source == "intendant-managed-cache" {
+        // Real test mode, with other Chromium side effects; see configuration.md.
+        command.arg("--test-type=gpu");
+    }
+}
+
+pub(crate) fn navigation(raw: Option<&str>) -> Result<Option<&str>, &'static str> {
+    let Some(raw) = raw else { return Ok(None) };
+    // URL parsers discard some control characters: reject instead of forwarding
+    // different bytes to Chromium. Preserve ordinary surrounding-space trimming.
+    if raw.chars().any(char::is_control) {
+        return Err("browser launch URL contains control characters");
+    }
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    if raw.starts_with('-') || url::Url::parse(raw).is_err() {
+        return Err("browser launch URL must be an absolute URL, not a switch");
+    }
+    Ok(Some(raw))
+}
+
+pub(crate) fn append_navigation(
+    command: &mut Command,
+    raw: Option<&str>,
+) -> Result<(), &'static str> {
+    let url = navigation(raw)?.unwrap_or("about:blank");
+    command.arg("--").arg(url);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_values_are_strict() {
+        assert!(!parse(None).unwrap());
+        assert!(!parse(Some(OsStr::new("0"))).unwrap());
+        assert!(parse(Some(OsStr::new("1"))).unwrap());
+        for raw in ["", "true", "yes", "on", "2", " 1", "--no-sandbox"] {
+            assert!(parse(Some(OsStr::new(raw))).is_err());
+        }
+    }
+
+    // This same test is a subprocess fixture, so dotenv really mutates the
+    // child's environment, never the test runner's or a real machine file.
+    #[test]
+    fn sealed_owner_survives_dotenv_and_multiple_successors() {
+        const HOP: &str = "NOTICE_TEST_HOP";
+        const OVERLAY: &str = "NOTICE_TEST_OVERLAY";
+        const EXPECTED: &str = "NOTICE_TEST_EXPECTED";
+        let test_name = std::thread::current().name().unwrap().to_owned();
+        let child_command = || {
+            let mut cmd = Command::new(std::env::current_exe().unwrap());
+            cmd.args(["--exact", &test_name, "--nocapture"]);
+            cmd
+        };
+        if let Ok(hop) = std::env::var(HOP) {
+            let hop: usize = hop.parse().unwrap();
+            initialize().unwrap();
+            let expected = std::env::var(EXPECTED).unwrap() == "1";
+            assert_eq!(current(), expected);
+            let overlay = std::env::var(OVERLAY).unwrap();
+            let dotenv = if overlay == "absent" {
+                String::new()
+            } else {
+                format!("{HIDE_TESTING_NOTICE_ENV}={overlay}\n")
+            };
+            dotenvy::from_read(std::io::Cursor::new(dotenv)).unwrap();
+            assert_eq!(current(), expected);
+            if hop == 0 && !expected && overlay != "absent" {
+                // For originally unset owner cases, the real dotenv load
+                // fills the ambient value, reproducing the review finding.
+                if std::env::var("NOTICE_TEST_UNSET").as_deref() == Ok("1") {
+                    assert_eq!(std::env::var(HIDE_TESTING_NOTICE_ENV).unwrap(), overlay);
+                }
+            }
+            if hop < 3 {
+                let mut cmd = child_command();
+                // Model any later ambient overlay as well, for explicit 0/1.
+                cmd.env(HIDE_TESTING_NOTICE_ENV, &overlay);
+                preserve_for_successor(&mut cmd);
+                assert_eq!(
+                    cmd.get_envs()
+                        .find(|(k, _)| *k == HIDE_TESTING_NOTICE_ENV)
+                        .unwrap()
+                        .1,
+                    Some(OsStr::new(if expected { "1" } else { "0" }))
+                );
+                assert!(cmd
+                    .env(HOP, (hop + 1).to_string())
+                    .status()
+                    .unwrap()
+                    .success());
+            }
+            return;
+        }
+        for owner in [None, Some("0"), Some("1")] {
+            for overlay in ["absent", "1", "invalid", "0"] {
+                let mut cmd = child_command();
+                cmd.env_clear()
+                    .env(HOP, "0")
+                    .env(OVERLAY, overlay)
+                    .env(EXPECTED, owner.unwrap_or("0"))
+                    .env("NOTICE_TEST_UNSET", if owner.is_none() { "1" } else { "0" });
+                if let Some(owner) = owner {
+                    cmd.env(HIDE_TESTING_NOTICE_ENV, owner);
+                }
+                assert!(cmd.status().unwrap().success());
+            }
+        }
+    }
+
+    #[test]
+    fn navigation_and_source_argv_boundary() {
+        for source in [
+            "intendant-managed-cache",
+            "managed-cache",
+            "env:INTENDANT_BROWSER_WORKSPACE_EXECUTABLE",
+            "env:INTENDANT_BROWSER_EXECUTABLE",
+            "system-browser",
+            "system-browser-provider",
+            "system-browser-env-opt-in",
+        ] {
+            for enabled in [false, true] {
+                for raw in [
+                    "--test-type=gpu",
+                    " --no-sandbox ",
+                    "-incognito",
+                    "--",
+                    "example.com",
+                    "https://",
+                    "http://[bad]",
+                    "https://example.com/\n--test-type=gpu",
+                    "\0",
+                ] {
+                    let mut cmd = Command::new("unused-browser");
+                    apply_testing_notice_policy(&mut cmd, source, enabled);
+                    let before: Vec<_> = cmd.get_args().map(|s| s.to_owned()).collect();
+                    assert!(append_navigation(&mut cmd, Some(raw)).is_err());
+                    assert_eq!(cmd.get_args().collect::<Vec<_>>(), before);
+                }
+                for raw in [
+                    None,
+                    Some(""),
+                    Some("  "),
+                    Some("about:blank"),
+                    Some("https://example.com/a?q=hello%20world&switch=--test-type=gpu#x"),
+                    Some("custom+app://open/item?x=1&y=2"),
+                    Some("mailto:user@example.com"),
+                    Some("file:///tmp/profile%20with%20spaces"),
+                    Some("chrome://version/"),
+                    Some(" https://example.com/ "),
+                ] {
+                    let mut cmd = Command::new("unused-browser");
+                    cmd.arg("--user-data-dir=/test/profile with spaces");
+                    apply_testing_notice_policy(&mut cmd, source, enabled);
+                    append_navigation(&mut cmd, raw).unwrap();
+                    let mut expected = vec!["--user-data-dir=/test/profile with spaces"];
+                    if enabled && source == "intendant-managed-cache" {
+                        expected.push("--test-type=gpu");
+                    }
+                    expected.extend([
+                        "--",
+                        raw.map(str::trim)
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or("about:blank"),
+                    ]);
+                    assert_eq!(cmd.get_args().collect::<Vec<_>>(), expected);
+                }
+            }
+        }
+    }
+}

--- a/src/bin/caller/handover/successor_exec.rs
+++ b/src/bin/caller/handover/successor_exec.rs
@@ -605,6 +605,9 @@ impl SuccessorExecLane {
         // against this and says the verdict out loud (the drainer's own
         // report can die with the drainer's prompt zero-session exit).
         cmd.env(OFFERED_SHA_ENV, expected_sha);
+        // Project dotenv may have filled an originally absent owner setting.
+        // Export sealed authority, never the now-ambient value, on every hop.
+        crate::browser_workspace::launch_policy::preserve_for_successor(&mut cmd);
         cmd.stdin(std::process::Stdio::null());
         let log_path = successor_log_path(state_root);
         match std::fs::OpenOptions::new()

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -4074,6 +4074,8 @@ async fn main() -> Result<(), CallerError> {
     // environment or starting any frontend/MCP listener. Successors replay both
     // pins; a changed file refuses startup instead of silently changing authority.
     let flags = parse_cli_flags()?;
+    browser_workspace::initialize_testing_notice_policy()
+        .map_err(|error| CallerError::Config(error.to_string()))?;
     browser_workspace::initialize_extension_policy(
         flags.browser_extension_policy.as_deref(),
         flags.browser_extension_policy_sha256.as_deref(),

--- a/src/bin/caller/service_mode.rs
+++ b/src/bin/caller/service_mode.rs
@@ -176,6 +176,39 @@ fn carried_env(get: impl Fn(&str) -> Option<String>) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Owner-only booleans must be captured before dotenv and persisted even when
+/// absent, so a service manager's environment cannot change the owner's default.
+const OWNER_BOOL_ENV_KEYS: &[&str] = &["INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE"];
+
+fn seal_owner_env(
+    envs: &mut Vec<(String, String)>,
+    get: impl Fn(&str) -> Option<std::ffi::OsString>,
+) -> Result<(), String> {
+    for &key in OWNER_BOOL_ENV_KEYS {
+        let invalid = || format!("{key} must be unset, 0, or 1");
+        // Command::envs gives the last explicit assignment precedence. Validate
+        // every explicit value, but do not replace a valid override with inheritance.
+        for (_, value) in envs.iter().filter(|(k, _)| k == key) {
+            if value != "0" && value != "1" {
+                return Err(invalid());
+            }
+        }
+        let explicit = envs.iter().rev().find(|(k, _)| k == key);
+        let raw = explicit
+            .map(|(_, v)| std::ffi::OsString::from(v))
+            .or_else(|| get(key));
+        let value = match raw.as_deref() {
+            None => "0",
+            Some(v) if v == "0" => "0",
+            Some(v) if v == "1" => "1",
+            _ => return Err(invalid()),
+        };
+        envs.retain(|(k, _)| k != key);
+        envs.push((key.to_string(), value.to_string()));
+    }
+    Ok(())
+}
+
 /* ── Quoting (each format has its own rules; get them right once) ── */
 
 fn sh_quote(value: &str) -> String {
@@ -451,6 +484,9 @@ fn cli_install(rest: &[String]) -> Result<(), String> {
     }
     validate_daemon_args(&daemon_args)?;
 
+    // The service subcommand runs before main loads any project dotenv files.
+    let mut envs = carried_env(|key| std::env::var(key).ok());
+    seal_owner_env(&mut envs, |key| std::env::var_os(key))?;
     let backend = detect_backend()?;
     let exe = current_exe()?.display().to_string();
     let home = crate::platform::home_dir();
@@ -461,7 +497,6 @@ fn cli_install(rest: &[String]) -> Result<(), String> {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("create log directory {}: {e}", parent.display()))?;
     }
-    let envs = carried_env(|key| std::env::var(key).ok());
     // Captured before any backend starts the daemon, so the first-boot
     // probe scans only log bytes this run produced (a reinstall over an
     // old crash log must not false-positive).
@@ -1050,6 +1085,10 @@ fn cli_run(rest: &[String]) -> i32 {
         eprintln!("error: {error}");
         return 2;
     }
+    if let Err(error) = seal_owner_env(&mut envs, |key| std::env::var_os(key)) {
+        eprintln!("error: {error}");
+        return 2;
+    }
     let exe = match current_exe() {
         Ok(exe) => exe,
         Err(error) => {
@@ -1368,6 +1407,105 @@ mod tests {
             next_backoff(60, BACKOFF_RESET_UPTIME_SECS),
             BACKOFF_START_SECS
         );
+    }
+
+    #[test]
+    fn owner_env_is_canonical_in_every_service_definition() {
+        let key = OWNER_BOOL_ENV_KEYS[0];
+        for (owner, expected) in [(None, "0"), (Some("0"), "0"), (Some("1"), "1")] {
+            let mut envs = carried_env(|_| Some("connect-value".into()));
+            seal_owner_env(&mut envs, |_| owner.map(Into::into)).unwrap();
+            assert_eq!(envs.len(), CARRIED_ENV_KEYS.len() + 1);
+            let daemon = args(&["--no-tui"]);
+            for system in [false, true] {
+                assert!(
+                    systemd_unit("/bin/intendant", &daemon, &envs, "/home/test", system)
+                        .contains(&format!("Environment=\"{key}={expected}\""))
+                );
+            }
+            assert!(
+                launchd_plist("/bin/intendant", &daemon, &envs, "/home/test", "/tmp/log").contains(
+                    &format!("<key>{key}</key>\n    <string>{expected}</string>")
+                )
+            );
+            let run = supervisor_run_args("/tmp/log", &envs, &daemon);
+            for boot in [false, true] {
+                assert!(schtasks_xml("intendant.exe", &run, "test", boot)
+                    .contains(&format!("--env {key}={expected}")));
+            }
+            assert!(
+                cron_line("/bin/intendant", &run).contains(&format!("'--env' '{key}={expected}'"))
+            );
+            // Round-trip the generated supervisor --env pairs. Explicit values
+            // win even if the service manager supplies a conflicting environment.
+            let mut replay: Vec<_> = run
+                .windows(2)
+                .filter(|w| w[0] == "--env")
+                .map(|w| {
+                    let (k, v) = w[1].split_once('=').unwrap();
+                    (k.into(), v.into())
+                })
+                .collect();
+            seal_owner_env(&mut replay, |_| Some("invalid-inherited".into())).unwrap();
+            assert_eq!(replay, envs);
+        }
+    }
+
+    #[test]
+    fn owner_env_rejects_invalid_without_echo_and_preserves_explicit_precedence() {
+        let key = OWNER_BOOL_ENV_KEYS[0];
+        for bad in ["", "true", "false", " 1", "1 ", "2", "secret\ninput"] {
+            let error = seal_owner_env(&mut Vec::new(), |_| Some(bad.into())).unwrap_err();
+            assert_eq!(error, format!("{key} must be unset, 0, or 1"));
+            let mut explicit = vec![(key.into(), bad.into())];
+            assert_eq!(
+                seal_owner_env(&mut explicit, |_| Some("1".into())),
+                Err(error)
+            );
+        }
+        for value in ["0", "1"] {
+            let mut explicit = vec![
+                ("OTHER".into(), "untouched".into()),
+                (key.into(), "0".into()),
+                (key.into(), value.into()),
+            ];
+            seal_owner_env(&mut explicit, |_| panic!("explicit value must win")).unwrap();
+            assert_eq!(
+                explicit,
+                vec![
+                    ("OTHER".into(), "untouched".into()),
+                    (key.into(), value.into())
+                ]
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn owner_env_rejects_non_unicode() {
+        use std::os::unix::ffi::OsStringExt;
+        assert!(
+            seal_owner_env(&mut Vec::new(), |_| Some(std::ffi::OsString::from_vec(
+                vec![255]
+            )))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn service_run_rejects_invalid_explicit_before_side_effects() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("must-not-exist/log");
+        assert_eq!(
+            cli_run(&args(&[
+                "--log",
+                log.to_str().unwrap(),
+                "--env",
+                "INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE=invalid-private-value"
+            ])),
+            2
+        );
+        assert!(!log.parent().unwrap().exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add an owner-startup opt-in for managed Chrome for Testing workspaces: `INTENDANT_BROWSER_WORKSPACE_HIDE_TESTING_NOTICE=1`. It is off by default, rejects values other than unset/0/1, and adds the fixed `--test-type=gpu` switch only to Intendant-managed browser launches. No arbitrary argument API or application-specific policy is introduced.

The value is sealed before project dotenv loading and explicitly retained across daemon successors. Launch navigation is validated before allocation and separated from switches by `--`; ordinary absolute/custom URLs remain supported. Exact launch arguments are retained in workspace metadata.

## Important scope
This is real Chromium test mode, not a purely cosmetic flag. Documentation lists the verified additional startup/extension test-mode effects in Chrome 152.0.7977.82 and makes no exhaustive cross-version guarantee. Existing extension approval, display isolation and launcher security settings are unchanged. No additional certificate, Safe Browsing or wallet-warning bypass is added.

## Validation
- Linux full workspace release `cargo check`: passed.
- Linux release build: passed; source manifest verified before and after compilation.
- Exact-module parser/argv and real dotenv subprocess/successor regressions: passed.
- Linux integrated `browser_workspace::` suite: 47 passed, 0 failed, 0 ignored.
- Formatting and diff checks: passed.
- Two independent static review rounds; successor environment inheritance and positional-URL findings corrected and re-reviewed.
- Real Linux managed-browser acceptance: fixed flag and positional delimiter recorded; testing notice absent in a fresh tab and an approved-extension notification. Window/capture operations remain native.

This does not claim the full cross-platform CI matrix has run. Native acceptance and source/build/command hashes are retained in the owner verification ledger.
